### PR TITLE
Websockets Support And Dual RPC Support

### DIFF
--- a/config.json
+++ b/config.json
@@ -23,5 +23,9 @@
         "maxLimit" : 1000,
         "maxOffset" : -1,
         "logRequests" : false
+    },
+    "rpcWebsockets" : {
+        "enabled" : true,
+        "port" : 5002
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "hivesmartcontracts",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "license": "MIT",
       "dependencies": {
         "@hiveio/dhive": "^1.0.1",
@@ -20,7 +20,7 @@
         "dotenv": "^6.2.0",
         "express": "^4.17.1",
         "fs-extra": "^6.0.1",
-        "jayson": "^2.1.2",
+        "jayson": "^4.0.0",
         "js-base64": "^2.6.4",
         "line-by-line": "^0.1.6",
         "loglevel": "^1.8.0",
@@ -117,6 +117,14 @@
         "whatwg-fetch": "^3.0.0"
       }
     },
+    "node_modules/@types/connect": {
+      "version": "3.4.35",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -124,9 +132,17 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "10.17.51",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.51.tgz",
-      "integrity": "sha512-KANw+MkL626tq90l++hGelbl67irOJzGhUJk6a1Bt8QHOeh9tztJx+L0AqttraWKinmZn7Qi5lJZJzx45Gq0dg=="
+      "version": "12.20.55",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="
+    },
+    "node_modules/@types/ws": {
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.7.tgz",
+      "integrity": "sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/accepts": {
       "version": "1.3.7",
@@ -962,6 +978,17 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/delay": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/delay/-/delay-5.0.0.tgz",
+      "integrity": "sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/denque": {
@@ -2377,22 +2404,57 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
+    "node_modules/isomorphic-ws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
+      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
     "node_modules/jayson": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/jayson/-/jayson-2.1.2.tgz",
-      "integrity": "sha512-2GejcQnEV35KYTXoBvzALIDdO/1oyEIoJHBnaJFhJhcurv0x2JqUXQW6xlDUhcNOpN9t+d2w+JGA6vOphb+5mg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jayson/-/jayson-4.0.0.tgz",
+      "integrity": "sha512-v2RNpDCMu45fnLzSk47vx7I+QUaOsox6f5X0CUlabAFwxoP+8MfAY0NQRFwOEYXIxm8Ih5y6OaEa5KYiQMkyAA==",
       "dependencies": {
-        "@types/node": "^10.3.5",
-        "commander": "^2.12.2",
+        "@types/connect": "^3.4.33",
+        "@types/node": "^12.12.54",
+        "@types/ws": "^7.4.4",
+        "commander": "^2.20.3",
+        "delay": "^5.0.0",
         "es6-promisify": "^5.0.0",
         "eyes": "^0.1.8",
+        "isomorphic-ws": "^4.0.1",
         "json-stringify-safe": "^5.0.1",
-        "JSONStream": "^1.3.1",
-        "lodash": "^4.17.11",
-        "uuid": "^3.2.1"
+        "JSONStream": "^1.3.5",
+        "uuid": "^8.3.2",
+        "ws": "^7.4.5"
       },
       "bin": {
         "jayson": "bin/jayson.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jayson/node_modules/ws": {
+      "version": "7.5.9",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
+      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/js-base64": {
@@ -2569,7 +2631,8 @@
     "node_modules/lodash": {
       "version": "4.17.20",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+      "dev": true
     },
     "node_modules/log-symbols": {
       "version": "3.0.0",
@@ -3673,6 +3736,7 @@
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.0.tgz",
       "integrity": "sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==",
+      "hasInstallScript": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "bip66": "^1.1.5",
@@ -4309,11 +4373,11 @@
       }
     },
     "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "bin": {
-        "uuid": "bin/uuid"
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/validate-npm-package-license": {
@@ -4767,6 +4831,14 @@
         "whatwg-fetch": "^3.0.0"
       }
     },
+    "@types/connect": {
+      "version": "3.4.35",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -4774,9 +4846,17 @@
       "dev": true
     },
     "@types/node": {
-      "version": "10.17.51",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.51.tgz",
-      "integrity": "sha512-KANw+MkL626tq90l++hGelbl67irOJzGhUJk6a1Bt8QHOeh9tztJx+L0AqttraWKinmZn7Qi5lJZJzx45Gq0dg=="
+      "version": "12.20.55",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="
+    },
+    "@types/ws": {
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.7.tgz",
+      "integrity": "sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==",
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "accepts": {
       "version": "1.3.7",
@@ -5492,6 +5572,11 @@
       "requires": {
         "object-keys": "^1.0.12"
       }
+    },
+    "delay": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/delay/-/delay-5.0.0.tgz",
+      "integrity": "sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw=="
     },
     "denque": {
       "version": "1.5.0",
@@ -6674,19 +6759,37 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
+    "isomorphic-ws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
+      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
+      "requires": {}
+    },
     "jayson": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/jayson/-/jayson-2.1.2.tgz",
-      "integrity": "sha512-2GejcQnEV35KYTXoBvzALIDdO/1oyEIoJHBnaJFhJhcurv0x2JqUXQW6xlDUhcNOpN9t+d2w+JGA6vOphb+5mg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jayson/-/jayson-4.0.0.tgz",
+      "integrity": "sha512-v2RNpDCMu45fnLzSk47vx7I+QUaOsox6f5X0CUlabAFwxoP+8MfAY0NQRFwOEYXIxm8Ih5y6OaEa5KYiQMkyAA==",
       "requires": {
-        "@types/node": "^10.3.5",
-        "commander": "^2.12.2",
+        "@types/connect": "^3.4.33",
+        "@types/node": "^12.12.54",
+        "@types/ws": "^7.4.4",
+        "commander": "^2.20.3",
+        "delay": "^5.0.0",
         "es6-promisify": "^5.0.0",
         "eyes": "^0.1.8",
+        "isomorphic-ws": "^4.0.1",
         "json-stringify-safe": "^5.0.1",
-        "JSONStream": "^1.3.1",
-        "lodash": "^4.17.11",
-        "uuid": "^3.2.1"
+        "JSONStream": "^1.3.5",
+        "uuid": "^8.3.2",
+        "ws": "^7.4.5"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "7.5.9",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
+          "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+          "requires": {}
+        }
       }
     },
     "js-base64": {
@@ -6833,7 +6936,8 @@
     "lodash": {
       "version": "4.17.20",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+      "dev": true
     },
     "log-symbols": {
       "version": "3.0.0",
@@ -8284,9 +8388,9 @@
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "dotenv": "^6.2.0",
     "express": "^4.17.1",
     "fs-extra": "^6.0.1",
-    "jayson": "^2.1.2",
+    "jayson": "^4.0.0",
     "js-base64": "^2.6.4",
     "line-by-line": "^0.1.6",
     "loglevel": "^1.8.0",

--- a/plugins/JsonRPCServer.js
+++ b/plugins/JsonRPCServer.js
@@ -292,6 +292,7 @@ const init = async (conf, callback) => {
     wssServer.websocket({
       port: rpcWebsockets.port,
     });
+    console.log(`Websockets RPC Node now listening on port ${rpcWebsockets.port}`); // eslint-disable-line
   }
 
   callback(null);

--- a/plugins/JsonRPCServer.js
+++ b/plugins/JsonRPCServer.js
@@ -236,11 +236,23 @@ function contractsRPC() {
   };
 }
 
+function dualRPC() {
+  const methods = {};
+  for (let method in jayson.server(blockchainRPC())._methods){
+    methods['blockchain.' + method] = jayson.server(blockchainRPC())._methods[method]
+  }
+  for (let method in jayson.server(contractsRPC())._methods){
+    methods['contracts.' + method] = jayson.server(contractsRPC())._methods[method]
+  }
+  return methods
+}
+
 const init = async (conf, callback) => {
   const {
     rpcNodePort,
     databaseURL,
     databaseName,
+    rpcWebsockets
   } = conf;
 
   database = new Database();
@@ -257,6 +269,7 @@ const init = async (conf, callback) => {
   }
   serverRPC.post('/blockchain', jayson.server(blockchainRPC()).middleware());
   serverRPC.post('/contracts', jayson.server(contractsRPC()).middleware());
+  serverRPC.post('/', jayson.server(dualRPC()).middleware());
   serverRPC.get('/', async (_, res) => {
     try {
       const status = await generateStatus();
@@ -271,6 +284,15 @@ const init = async (conf, callback) => {
     .listen(rpcNodePort, () => {
       console.log(`RPC Node now listening on port ${rpcNodePort}`); // eslint-disable-line
     });
+
+
+  if (rpcWebsockets.enabled){
+    const wssServer = new jayson.Server(dualRPC());
+
+    wssServer.websocket({
+      port: rpcWebsockets.port,
+    });
+  }
 
   callback(null);
 };

--- a/plugins/JsonRPCServer.js
+++ b/plugins/JsonRPCServer.js
@@ -238,10 +238,10 @@ function contractsRPC() {
 
 function dualRPC() {
   const methods = {};
-  for (let method in jayson.server(blockchainRPC())._methods){
+  for (const method in jayson.server(blockchainRPC())._methods){
     methods['blockchain.' + method] = jayson.server(blockchainRPC())._methods[method]
   }
-  for (let method in jayson.server(contractsRPC())._methods){
+  for (const method in jayson.server(contractsRPC())._methods){
     methods['contracts.' + method] = jayson.server(contractsRPC())._methods[method]
   }
   return methods


### PR DESCRIPTION
This PR adds support for websockets in the JSON RPC. It comes with the following config options:

```json
"rpcWebsockets" : {
        "enabled" : true,
        "port" : 5002
    }
```

The methods are the same as with HTTP, except there's just one path and it follows the hive style of METHOD_FAMILY.METHOD_NAME, for example: 

```json
{ "jsonrpc": "2.0", "method": "contracts.getContract", "params" : {"name" : "tokens"},  "id": 0 }
```

which would be a call to `/contracts` with the method `getContract`. The other METHOD_FAMILY is blockchain for `/blockchain` requests.


This type of requests can be done via HTTP as well, by providing no path. So the same request from above can be called to `/`.
