### PR TITLE
Improve performance of light nodes

### DIFF
--- a/app.js
+++ b/app.js
@@ -182,11 +182,13 @@ const initLightNode = async () => {
     databaseName,
     lightNode,
     blocksToKeep,
+    startHiveBlock,
+    genesisHiveBlock,
   } = conf;
   const database = new Database();
   await database.init(databaseURL, databaseName, lightNode.enabled, blocksToKeep);
 
-  if (!lightNode.enabled) {
+  if (!lightNode.enabled && startHiveBlock !== genesisHiveBlock) {
     // check if was previously a light node
     const wasLightNode = await database.wasLightNodeBefore();
     if (wasLightNode) {

--- a/app.js
+++ b/app.js
@@ -9,6 +9,7 @@ const jsonRPCServer = require('./plugins/JsonRPCServer');
 const streamer = require('./plugins/Streamer');
 const replay = require('./plugins/Replay');
 const p2p = require('./plugins/P2P');
+const lightNodePlugin = require('./plugins/LightNode');
 
 const conf = require('./config');
 const { Database } = require('./libs/Database');
@@ -211,6 +212,9 @@ const start = async (requestedPlugins) => {
       res = await loadPlugin(p2p, requestedPlugins);
       if (res && res.payload === null) {
         res = await loadPlugin(jsonRPCServer, requestedPlugins);
+        if (res && res.payload === null) {
+          res = await loadPlugin(lightNodePlugin, requestedPlugins);
+        }
       }
     }
   }
@@ -231,7 +235,7 @@ const replayBlocksLog = async () => {
 program
   .version(packagejson.version)
   .option('-r, --replay [type]', 'replay the blockchain from [file]', /^(file)$/i)
-  .option('-p, --plugins <plugins>', 'which plugins to run. (Available plugins: Blockchain,Streamer,P2P,JsonRPCServer', 'Blockchain,Streamer,P2P,JsonRPCServer')
+  .option('-p, --plugins <plugins>', 'which plugins to run. (Available plugins: Blockchain,Streamer,P2P,JsonRPCServer,LightNode', 'Blockchain,Streamer,P2P,JsonRPCServer,LightNode')
   .parse(process.argv);
 
 const requestedPlugins = program.plugins.split(',');

--- a/app.js
+++ b/app.js
@@ -184,9 +184,9 @@ const initLightNode = async () => {
     blocksToKeep,
   } = conf;
   const database = new Database();
-  await database.init(databaseURL, databaseName, lightNode, blocksToKeep);
+  await database.init(databaseURL, databaseName, lightNode.enabled, blocksToKeep);
 
-  if (!lightNode) {
+  if (!lightNode.enabled) {
     // check if was previously a light node
     const wasLightNode = await database.wasLightNodeBefore();
     if (wasLightNode) {

--- a/app.js
+++ b/app.js
@@ -192,7 +192,7 @@ const initLightNode = async () => {
     // check if was previously a light node
     const wasLightNode = await database.wasLightNodeBefore();
     if (wasLightNode) {
-      console.log('Can\'t switch from a node, which was previously a light node, to a full node. Please restore your database from a full node dump.');
+      console.log('Looks like your database belongs to a light node. Did you forget to set lightNode.enabled = true in the config.json? Switching from a light node to a full node is not possible - you would have to do a full database restore in such a case.');
       await gracefulShutdown();
       process.exit();
     }

--- a/app.js
+++ b/app.js
@@ -147,6 +147,7 @@ const stop = async () => {
   }
 
   await unloadPlugin(blockchain);
+  await unloadPlugin(lightNodePlugin);
 
   return res ? res.payload : null;
 };

--- a/config.json
+++ b/config.json
@@ -18,6 +18,7 @@
     "defaultLogLevel": "warn",
     "lightNode": false,
     "blocksToKeep": 864000,
+    "lightNodeCleanupInterval": 600000,
     "domain" : "",
     "rpcConfig" : {
         "maxLimit" : 1000,

--- a/config.json
+++ b/config.json
@@ -16,10 +16,12 @@
     "genesisHiveBlock": 41967000,
     "witnessEnabled": true,
     "defaultLogLevel": "warn",
-    "lightNode": false,
-    "blocksToKeep": 864000,
-    "lightNodeCleanupInterval": 600000,
     "domain" : "",
+    "lightNode": {
+        "enabled": false,
+        "blocksToKeep": 864000,
+        "cleanupInterval": 600000
+    },
     "rpcConfig" : {
         "maxLimit" : 1000,
         "maxOffset" : -1,

--- a/find_divergent_block.js
+++ b/find_divergent_block.js
@@ -126,7 +126,7 @@ async function findDivergentBlock() {
     }
   } else {
     let low = 0;
-    if (lightNode) {
+    if (lightNode.enabled) {
         const firstBlock = await chain.findOne({ blockNumber: { $gt: 0 } });
         if (firstBlock) {
             low = firstBlock.blockNumber;

--- a/libs/Block.js
+++ b/libs/Block.js
@@ -104,20 +104,8 @@ class Block {
     }
   }
 
-  /**
-   * Try cleaning up blocks after every 100 blocks if node is a light node.
-   * @param database
-   * @returns {Promise<void>}
-   */
-  async cleanupLightNode(database) {
-    if (this.blockNumber % 100 === 0) {
-      await database.cleanupLightNode();
-    }
-  }
-
   // produce the block (deploy a smart contract or execute a smart contract)
   async produceBlock(database, jsVMTimeout, mainBlock) {
-    await this.cleanupLightNode(database);
     await this.blockAdjustments(database);
 
     const nbTransactions = this.transactions.length;

--- a/plugins/Blockchain.js
+++ b/plugins/Blockchain.js
@@ -166,15 +166,13 @@ const init = async (conf, callback) => {
   const {
     databaseURL,
     databaseName,
-    lightNode,
-    blocksToKeep,
   } = conf;
   javascriptVMTimeout = conf.javascriptVMTimeout; // eslint-disable-line prefer-destructuring
   enableHashVerification = conf.enableHashVerification; // eslint-disable-line prefer-destructuring
   log.setDefaultLevel(conf.defaultLogLevel ? conf.defaultLogLevel : 'warn');
 
   database = new Database();
-  await database.init(databaseURL, databaseName, lightNode, blocksToKeep);
+  await database.init(databaseURL, databaseName);
 
   await createGenesisBlock(conf);
 

--- a/plugins/JsonRPCServer.js
+++ b/plugins/JsonRPCServer.js
@@ -56,9 +56,9 @@ async function generateStatus() {
       result.chainId = config.chainId;
 
       // get light node config of the SSC node
-      result.lightNode = config.lightNode;
-      if (config.lightNode) {
-        result.blocksToKeep = config.blocksToKeep;
+      result.lightNode = config.lightNode.enabled;
+      if (result.lightNode) {
+        result.blocksToKeep = config.lightNode.blocksToKeep;
       }
 
       // first block currently stored by light node

--- a/plugins/LightNode.js
+++ b/plugins/LightNode.js
@@ -22,18 +22,16 @@ const manageLightNode = async (cleanupInterval) => {
 const init = async (conf, callback) => {
     const {
         lightNode,
-        lightNodeCleanupInterval,
-        blocksToKeep,
         databaseURL,
         databaseName,
     } = conf;
 
-    if (!lightNode) {
+    if (!lightNode.enabled) {
         console.log('LightNode not started as it is not enabled in the config.json file');
     } else {
         database = new Database();
-        await database.init(databaseURL, databaseName, lightNode, blocksToKeep);
-        manageLightNode(lightNodeCleanupInterval ? lightNodeCleanupInterval : 600000);
+        await database.init(databaseURL, databaseName, lightNode.enabled, lightNode.blocksToKeep);
+        manageLightNode(lightNode.cleanupInterval ? lightNode.cleanupInterval : 600000);
     }
     callback(null);
 };

--- a/plugins/LightNode.js
+++ b/plugins/LightNode.js
@@ -1,0 +1,71 @@
+/* eslint-disable no-console */
+/* eslint-disable no-await-in-loop */
+const { IPC } = require('../libs/IPC');
+const { Database } = require('../libs/Database');
+
+const PLUGIN_NAME = 'LightNode';
+const PLUGIN_PATH = require.resolve(__filename);
+
+const ipc = new IPC(PLUGIN_NAME);
+let database = null;
+
+let manageLightNodeTimeoutHandler = null;
+
+const manageLightNode = async (cleanupInterval) => {
+    console.log('Cleaning up blocks / transactions not needed by light node...');
+    await database.cleanupLightNode();
+
+    manageLightNodeTimeoutHandler = setTimeout(() => {
+        manageLightNode(cleanupInterval);
+    }, cleanupInterval);
+};
+
+const init = async (conf, callback) => {
+    const {
+        lightNode,
+        lightNodeCleanupInterval,
+        blocksToKeep,
+        databaseURL,
+        databaseName,
+    } = conf;
+
+    if (!lightNode) {
+        console.log('LightNode not started as it is not enabled in the config.json file');
+    } else {
+        database = new Database();
+        await database.init(databaseURL, databaseName, lightNode, blocksToKeep);
+        manageLightNode(lightNodeCleanupInterval ? lightNodeCleanupInterval : 600000);
+    }
+    callback(null);
+};
+
+function stop() {
+    if (manageLightNodeTimeoutHandler) clearTimeout(manageLightNodeTimeoutHandler);
+    if (database) database.close();
+}
+
+ipc.onReceiveMessage((message) => {
+    const {
+        action,
+        payload,
+    } = message;
+
+    switch (action) {
+        case 'init':
+            init(payload, (res) => {
+                console.log('successfully initialized'); // eslint-disable-line no-console
+                ipc.reply(message, res);
+            });
+            break;
+        case 'stop':
+            ipc.reply(message, stop());
+            console.log('successfully stopped'); // eslint-disable-line no-console
+            break;
+        default:
+            ipc.reply(message);
+            break;
+    }
+});
+
+module.exports.PLUGIN_NAME = PLUGIN_NAME;
+module.exports.PLUGIN_PATH = PLUGIN_PATH;

--- a/plugins/LightNode.js
+++ b/plugins/LightNode.js
@@ -12,7 +12,6 @@ let database = null;
 let manageLightNodeTimeoutHandler = null;
 
 const manageLightNode = async (cleanupInterval) => {
-    console.log('Cleaning up blocks / transactions not needed by light node...');
     await database.cleanupLightNode();
 
     manageLightNodeTimeoutHandler = setTimeout(() => {

--- a/restore_partial.js
+++ b/restore_partial.js
@@ -259,7 +259,7 @@ async function restorePartial() {
     lightNode,
   } = conf;
 
-  if (lightNode && !drop) {
+  if (lightNode.enabled && !drop) {
     console.log('Restoring a light node database is not supported. Please add the \'-d\' flag to completely restore your db.');
     return;
   }
@@ -270,7 +270,7 @@ async function restorePartial() {
 
   let divergentBlockNum = Number.MAX_SAFE_INTEGER;
   if (!drop) {
-    divergentBlockNum = await findDivergentBlock(chain, lightNode);
+    divergentBlockNum = await findDivergentBlock(chain, lightNode.enabled);
     if (divergentBlockNum === -1) {
       console.log('ok');
       await database.close();


### PR DESCRIPTION
This PR improves the performance of light nodes:
* added new plugin `LightNode` which cleans up blocks / transactions
* only started if `lightNode.enabled` flag is `true` in `config.json`
* removed cleanup of blocks / transactions from `Streamer`
* move light node config to own json node in `config.json`
* add `cleanupInterval` to light node config with default value of `600000` (600 seconds / 10 minutes)
* fix bug where full nodes won't start when syncing from genesis, see issue #11 

Default values of the new json node in `config.json`:
```
"lightNode": {
    "enabled": false,
    "blocksToKeep": 864000,
    "cleanupInterval": 600000
},
```