### PR TITLE
Witness approval expiration

### DIFF
--- a/contracts/witnesses.js
+++ b/contracts/witnesses.js
@@ -10,7 +10,7 @@ const MAX_ROUNDS_MISSED_IN_A_ROW = 3; // after that the witness is disabled
 const MAX_ROUND_PROPOSITION_WAITING_PERIOD = 40; // number of blocks
 const NB_TOKENS_TO_REWARD = '0.01902586'; // inflation.js tokens per block
 const NB_TOKENS_NEEDED_BEFORE_REWARDING = '0.0951293'; // 5x to reward
-const WITNESS_VOTE_EXPIRE_DAYS = 180; // Approximately half a year
+const WITNESS_VOTE_EXPIRE_BLOCKS = 5184000; // Approximately half a year, 20 blocks a minute * 60 minutes an hour * 24 hours a day * 180 days
 // eslint-disable-next-line no-template-curly-in-string
 const UTILITY_TOKEN_SYMBOL = "'${CONSTANTS.UTILITY_TOKEN_SYMBOL}$'";
 // eslint-disable-next-line no-template-curly-in-string
@@ -45,7 +45,7 @@ actions.createSSC = async () => {
       witnessSignaturesRequired: NB_WITNESSES_SIGNATURES_REQUIRED,
       maxRoundsMissedInARow: MAX_ROUNDS_MISSED_IN_A_ROW,
       maxRoundPropositionWaitingPeriod: MAX_ROUND_PROPOSITION_WAITING_PERIOD,
-      witnessVoteExpireDays: WITNESS_VOTE_EXPIRE_DAYS,
+      witnessVoteExpireDays: WITNESS_VOTE_EXPIRE_BLOCKS,
     };
 
     await api.db.insert('params', params);
@@ -257,7 +257,7 @@ actions.approve = async (payload) => {
           account: api.sender,
           approvals: 0,
           approvalWeight: { $numberDecimal: '0' },
-          lastVoteDate: new Date(`${api.hiveBlockTimestamp}.000Z`),
+          lastVoteBlock: api.blockNumber,
         };
 
         acct = await api.db.insert('accounts', acct);
@@ -288,7 +288,7 @@ actions.approve = async (payload) => {
 
           acct.approvals += 1;
           acct.approvalWeight = approvalWeight;
-          acct.lastVoteDate = new Date(`${api.hiveBlockTimestamp}.000Z`);
+          acct.lastVoteBlock = api.blockNumber;
 
           await api.db.update('accounts', acct);
 
@@ -315,7 +315,7 @@ actions.disapprove = async (payload) => {
           account: api.sender,
           approvals: 0,
           approvalWeight: { $numberDecimal: '0' },
-          lastVoteDate: new Date(`${api.hiveBlockTimestamp}.000Z`),
+          lastVoteBlock: api.blockNumber,
         };
 
         await api.db.insert('accounts', acct);
@@ -342,7 +342,7 @@ actions.disapprove = async (payload) => {
 
           acct.approvals -= 1;
           acct.approvalWeight = approvalWeight;
-          acct.lastVoteDate = new Date(`${api.hiveBlockTimestamp}.000Z`);
+          acct.lastVoteBlock = api.blockNumber;
 
           await api.db.update('accounts', acct);
 

--- a/contracts/witnesses.js
+++ b/contracts/witnesses.js
@@ -10,6 +10,7 @@ const MAX_ROUNDS_MISSED_IN_A_ROW = 3; // after that the witness is disabled
 const MAX_ROUND_PROPOSITION_WAITING_PERIOD = 40; // number of blocks
 const NB_TOKENS_TO_REWARD = '0.01902586'; // inflation.js tokens per block
 const NB_TOKENS_NEEDED_BEFORE_REWARDING = '0.0951293'; // 5x to reward
+const WITNESS_VOTE_EXPIRE_DAYS = 180; // Approximately half a year
 // eslint-disable-next-line no-template-curly-in-string
 const UTILITY_TOKEN_SYMBOL = "'${CONSTANTS.UTILITY_TOKEN_SYMBOL}$'";
 // eslint-disable-next-line no-template-curly-in-string
@@ -44,6 +45,7 @@ actions.createSSC = async () => {
       witnessSignaturesRequired: NB_WITNESSES_SIGNATURES_REQUIRED,
       maxRoundsMissedInARow: MAX_ROUNDS_MISSED_IN_A_ROW,
       maxRoundPropositionWaitingPeriod: MAX_ROUND_PROPOSITION_WAITING_PERIOD,
+      witnessVoteExpireDays: WITNESS_VOTE_EXPIRE_DAYS,
     };
 
     await api.db.insert('params', params);
@@ -174,6 +176,7 @@ actions.updateWitnessesApprovals = async (payload) => {
       .toFixed(GOVERNANCE_TOKEN_PRECISION);
 
     acct.approvalWeight = approvalWeight;
+    acct.lastVoteDate = new Date(`${api.hiveBlockTimestamp}.000Z`);
 
     if (!api.BigNumber(deltaApprovalWeight).eq(0)) {
       await api.db.update('accounts', acct);
@@ -255,6 +258,7 @@ actions.approve = async (payload) => {
           account: api.sender,
           approvals: 0,
           approvalWeight: { $numberDecimal: '0' },
+          lastVoteDate: new Date(`${api.hiveBlockTimestamp}.000Z`),
         };
 
         acct = await api.db.insert('accounts', acct);
@@ -285,6 +289,7 @@ actions.approve = async (payload) => {
 
           acct.approvals += 1;
           acct.approvalWeight = approvalWeight;
+          acct.lastVoteDate = new Date(`${api.hiveBlockTimestamp}.000Z`);
 
           await api.db.update('accounts', acct);
 
@@ -311,6 +316,7 @@ actions.disapprove = async (payload) => {
           account: api.sender,
           approvals: 0,
           approvalWeight: { $numberDecimal: '0' },
+          lastVoteDate: new Date(`${api.hiveBlockTimestamp}.000Z`),
         };
 
         await api.db.insert('accounts', acct);
@@ -337,6 +343,7 @@ actions.disapprove = async (payload) => {
 
           acct.approvals -= 1;
           acct.approvalWeight = approvalWeight;
+          acct.lastVoteDate = new Date(`${api.hiveBlockTimestamp}.000Z`);
 
           await api.db.update('accounts', acct);
 

--- a/contracts/witnesses.js
+++ b/contracts/witnesses.js
@@ -54,6 +54,18 @@ actions.createSSC = async () => {
     const params = await api.db.findOne('params', {});
     params.witnessApproveExpireBlocks = WITNESS_APPROVE_EXPIRE_BLOCKS;
     await api.db.update('params', params);
+
+    let offset = 0;
+    let accounts;
+    do {
+      accounts = await api.db.find('accounts', { }, 1000, offset, []);
+      for (let i = 0; i < accounts.length; i += 1) {
+        const account = accounts[i];
+        account.lastApproveBlock = api.blockNumber;
+        await api.db.update('accounts', account);
+      }
+      offset += 1000;
+    } while (accounts.length === 1000);
   }
 };
 

--- a/contracts/witnesses.js
+++ b/contracts/witnesses.js
@@ -52,7 +52,7 @@ actions.createSSC = async () => {
     await api.db.insert('params', params);
   } else {
     const params = await api.db.findOne('params', {});
-    
+
     // This should be removed after being deployed
     if (!params.witnessApproveExpireBlocks) {
       let offset = 0;
@@ -68,7 +68,7 @@ actions.createSSC = async () => {
       } while (accounts.length === 1000);
     }
     // End block to remove
-  
+
     params.witnessApproveExpireBlocks = WITNESS_APPROVE_EXPIRE_BLOCKS;
     await api.db.update('params', params);
   }
@@ -147,6 +147,11 @@ const updateWitnessRank = async (witness, approvalWeight) => {
     )
       .plus(approvalWeight)
       .toFixed(GOVERNANCE_TOKEN_PRECISION);
+
+    // Don't allow witness to have negative approval weight.
+    if (api.BigNumber(witnessRec.approvalWeight.$numberDecimal).lt(0)) {
+      witnessRec.approvalWeight.$numberDecimal = api.BigNumber(0);
+    }
 
     await api.db.update('witnesses', witnessRec);
 

--- a/contracts/witnesses.js
+++ b/contracts/witnesses.js
@@ -421,11 +421,7 @@ const changeCurrentWitness = async () => {
     round,
     maxRoundsMissedInARow,
     maxRoundPropositionWaitingPeriod,
-    witnessApproveExpireBlocks,
   } = params;
-
-  // remove expired approvals before changing
-  await findAndExpireApprovals(witnessApproveExpireBlocks);
 
   let witnessFound = false;
   // get a deterministic random weight
@@ -572,7 +568,11 @@ const manageWitnessesSchedule = async () => {
     numberOfTopWitnesses,
     numberOfWitnessSlots,
     maxRoundPropositionWaitingPeriod,
+    witnessApproveExpireBlocks,
   } = params;
+
+  // remove expired approvals before changing
+  await findAndExpireApprovals(witnessApproveExpireBlocks);
 
   // check the current schedule
   const currentBlock = lastVerifiedBlockNumber + 1;

--- a/contracts/witnesses.js
+++ b/contracts/witnesses.js
@@ -267,7 +267,7 @@ const removeApproval = async (from, to, acct, manual = true) => {
   // a user can only disapprove if it already approved a witness
   if (api.assert(approval !== null, 'you have not approved this witness')) {
     let account = acct;
-    if (!acct) {
+    if (!acct || acct.account !== from) {
       account = await api.db.findOne('accounts', { account: from });
     }
     await api.db.remove('approvals', approval);
@@ -401,7 +401,7 @@ const findAndExpireApprovals = async (witnessApproveExpireBlocks) => {
   // Do up to 1000 per round, starting with oldest
   const accounts = await api.db.find('accounts', { lastApproveBlock: { $lt: api.blockNumber - witnessApproveExpireBlocks }, approvals: { $gt: 0 } }, 1000, 0, [{ index: 'lastApproveBlock', descending: false }]);
   for (let i = 0; i < accounts.length; i += 1) {
-    await expireAllUserApprovals(accounts[i].account);
+    await expireAllUserApprovals(accounts[i]);
   }
 };
 

--- a/contracts/witnesses.js
+++ b/contracts/witnesses.js
@@ -740,6 +740,7 @@ const findAndExpireApprovals = async () => {
   const accounts = await api.db.find('accounts', { lastApproveBlock: { $gt: api.blockNumber + witnessApproveExpireBlocks }, approvalExpired: false }, 1000, 0, [{ index: 'lastApproveBlock', descending: false }]);
   for (let i = 0; i < accounts.length; i += 1) {
     await expireAllUserApprovals(accounts[i].account);
+    api.emit('approvalsExpired', { account: accounts[i].account });
   }
 };
 

--- a/contracts/witnesses.js
+++ b/contracts/witnesses.js
@@ -411,6 +411,7 @@ const expireAllUserApprovals = async (acct) => {
   const account = acct;
   account.approvals = 0;
   account.approvalWeight = balance.stake || 0;
+  await api.db.update('accounts', account);
   api.emit('witnessApprovalsExpired', { account: acct.account });
 };
 

--- a/contracts/witnesses.js
+++ b/contracts/witnesses.js
@@ -408,9 +408,19 @@ const expireAllUserApprovals = async (acct) => {
     const approval = approvals[i];
     await removeApproval(approval, acct, balance, false);
   }
+  let approvalWeight = 0;
+  if (balance && balance.stake) {
+    approvalWeight = balance.stake;
+  }
+
+  if (balance && balance.delegationsIn) {
+    approvalWeight = api.BigNumber(approvalWeight)
+      .plus(balance.delegationsIn)
+      .toFixed(GOVERNANCE_TOKEN_PRECISION);
+  }
   const account = acct;
   account.approvals = 0;
-  account.approvalWeight = balance.stake || 0;
+  account.approvalWeight = approvalWeight;
   await api.db.update('accounts', account);
   api.emit('witnessApprovalsExpired', { account: acct.account });
 };

--- a/contracts/witnesses.js
+++ b/contracts/witnesses.js
@@ -12,6 +12,7 @@ const NB_TOKENS_TO_REWARD = '0.01902586'; // inflation.js tokens per block
 const NB_TOKENS_NEEDED_BEFORE_REWARDING = '0.0951293'; // 5x to reward
 // eslint-disable-next-line max-len
 const WITNESS_APPROVE_EXPIRE_BLOCKS = 5184000; // Approximately half a year, 20 blocks a minute * 60 minutes an hour * 24 hours a day * 180 days
+const WITNESS_MAX_ACCOUNT_EXPIRE_PER_BLOCK = 10;
 // eslint-disable-next-line no-template-curly-in-string
 const UTILITY_TOKEN_SYMBOL = "'${CONSTANTS.UTILITY_TOKEN_SYMBOL}$'";
 // eslint-disable-next-line no-template-curly-in-string
@@ -426,8 +427,8 @@ const expireAllUserApprovals = async (acct) => {
 };
 
 const findAndExpireApprovals = async (witnessApproveExpireBlocks) => {
-  // Do up to 1000 per round, starting with oldest
-  const accounts = await api.db.find('accounts', { lastApproveBlock: { $lt: api.blockNumber - witnessApproveExpireBlocks }, approvals: { $gt: 0 } }, 1000, 0, [{ index: 'lastApproveBlock', descending: false }]);
+  // Do up to WITNESS_MAX_ACCOUNT_EXPIRE_PER_BLOCK(currently 10) per round, starting with oldest.
+  const accounts = await api.db.find('accounts', { lastApproveBlock: { $lt: api.blockNumber - witnessApproveExpireBlocks }, approvals: { $gt: 0 } }, WITNESS_MAX_ACCOUNT_EXPIRE_PER_BLOCK, 0, [{ index: 'lastApproveBlock', descending: false }]);
   for (let i = 0; i < accounts.length; i += 1) {
     await expireAllUserApprovals(accounts[i]);
   }

--- a/contracts/witnesses.js
+++ b/contracts/witnesses.js
@@ -393,7 +393,7 @@ actions.disapprove = async (payload) => {
       }
 
       if (api.assert(acct.approvals > 0, 'no approvals found')) {
-        const approval = await api.db.find('approvals', { from: acct.account, to: witness });
+        const approval = await api.db.findOne('approvals', { from: acct.account, to: witness });
         const balance = await api.db.findOneInTable('tokens', 'balances', { account: api.sender, symbol: GOVERNANCE_TOKEN_SYMBOL });
         await removeApproval(approval, acct, balance, true);
       }

--- a/contracts/witnesses.js
+++ b/contracts/witnesses.js
@@ -296,13 +296,12 @@ const removeApproval = async (approval, acct, blnce, manual = true) => {
         .toFixed(GOVERNANCE_TOKEN_PRECISION);
     }
 
-    account.approvals -= 1;
-    account.approvalWeight = approvalWeight;
     if (manual) {
+      account.approvals -= 1;
+      account.approvalWeight = approvalWeight;
       account.lastApproveBlock = api.blockNumber;
+      await api.db.update('accounts', account);
     }
-
-    await api.db.update('accounts', account);
 
     // update the rank of the witness that received the disapproval
     await updateWitnessRank(to, `-${approvalWeight}`);
@@ -409,6 +408,9 @@ const expireAllUserApprovals = async (acct) => {
     const approval = approvals[i];
     await removeApproval(approval, acct, balance, false);
   }
+  const account = acct;
+  account.approvals = 0;
+  account.approvalWeight = balance.stake || 0;
   api.emit('witnessApprovalsExpired', { account: acct.account });
 };
 

--- a/contracts/witnesses.js
+++ b/contracts/witnesses.js
@@ -376,8 +376,7 @@ const expireAllUserApprovals = async (username) => {
     const approval = approvals[i];
     await removeApproval(approval.from, approval.to, false);
   }
-  const acct = await api.db.findOne('accounts', { account: username });
-  await api.db.update('accounts', acct);
+  api.emit('approvalsExpired', { account: username });
 };
 
 const findAndExpireApprovals = async () => {
@@ -389,7 +388,6 @@ const findAndExpireApprovals = async () => {
   const accounts = await api.db.find('accounts', { lastApproveBlock: { $lt: api.blockNumber - witnessApproveExpireBlocks }, approvals: { $gt: 0 } }, 1000, 0, [{ index: 'lastApproveBlock', descending: false }]);
   for (let i = 0; i < accounts.length; i += 1) {
     await expireAllUserApprovals(accounts[i].account);
-    api.emit('approvalsExpired', { account: accounts[i].account });
   }
 };
 

--- a/contracts/witnesses.js
+++ b/contracts/witnesses.js
@@ -51,10 +51,6 @@ actions.createSSC = async () => {
 
     await api.db.insert('params', params);
   } else {
-    const params = await api.db.findOne('params', {});
-    params.witnessApproveExpireBlocks = WITNESS_APPROVE_EXPIRE_BLOCKS;
-    await api.db.update('params', params);
-
     // This should be removed after being deployed
     if (!params.witnessApproveExpireBlocks) {
       let offset = 0;
@@ -70,6 +66,10 @@ actions.createSSC = async () => {
       } while (accounts.length === 1000);
     }
     // End block to remove
+    
+    const params = await api.db.findOne('params', {});
+    params.witnessApproveExpireBlocks = WITNESS_APPROVE_EXPIRE_BLOCKS;
+    await api.db.update('params', params);
   }
 };
 

--- a/contracts/witnesses.js
+++ b/contracts/witnesses.js
@@ -50,6 +50,10 @@ actions.createSSC = async () => {
     };
 
     await api.db.insert('params', params);
+  } else {
+    const params = await api.db.findOne('params', {});
+    params.witnessApproveExpireBlocks = WITNESS_APPROVE_EXPIRE_BLOCKS;
+    await api.db.update('params', params);
   }
 };
 

--- a/contracts/witnesses.js
+++ b/contracts/witnesses.js
@@ -176,7 +176,6 @@ actions.updateWitnessesApprovals = async (payload) => {
       .toFixed(GOVERNANCE_TOKEN_PRECISION);
 
     acct.approvalWeight = approvalWeight;
-    acct.lastVoteDate = new Date(`${api.hiveBlockTimestamp}.000Z`);
 
     if (!api.BigNumber(deltaApprovalWeight).eq(0)) {
       await api.db.update('accounts', acct);

--- a/contracts/witnesses.js
+++ b/contracts/witnesses.js
@@ -405,7 +405,7 @@ const expireAllUserApprovals = async (acct) => {
     const approval = approvals[i];
     await removeApproval(approval.from, approval.to, acct, false);
   }
-  api.emit('approvalsExpired', { account: acct.account });
+  api.emit('witnessApprovalsExpired', { account: acct.account });
 };
 
 const findAndExpireApprovals = async (witnessApproveExpireBlocks) => {

--- a/contracts/witnesses.js
+++ b/contracts/witnesses.js
@@ -376,7 +376,7 @@ const expireAllUserApprovals = async (username) => {
     const approval = approvals[i];
     await removeApproval(approval.from, approval.to, false);
   }
-  const acct = await api.db.findOne('accounts', { account: api.sender });
+  const acct = await api.db.findOne('accounts', { account: username });
   acct.approvalExpired = true;
   await api.db.update('accounts', acct);
 };
@@ -387,7 +387,7 @@ const findAndExpireApprovals = async () => {
     witnessApproveExpireBlocks,
   } = params;
   // Do up to 1000 per round, starting with oldest
-  const accounts = await api.db.find('accounts', { lastApproveBlock: { $gt: api.blockNumber + witnessApproveExpireBlocks }, approvalExpired: false }, 1000, 0, [{ index: 'lastApproveBlock', descending: false }]);
+  const accounts = await api.db.find('accounts', { lastApproveBlock: { $lt: api.blockNumber - witnessApproveExpireBlocks }, approvalExpired: false }, 1000, 0, [{ index: 'lastApproveBlock', descending: false }]);
   for (let i = 0; i < accounts.length; i += 1) {
     await expireAllUserApprovals(accounts[i].account);
     api.emit('approvalsExpired', { account: accounts[i].account });

--- a/contracts/witnesses.js
+++ b/contracts/witnesses.js
@@ -247,7 +247,7 @@ const removeApproval = async (from, to, manual = true) => {
 
   // a user can only disapprove if it already approved a witness
   if (api.assert(approval !== null, 'you have not approved this witness')) {
-    const acct = await api.db.findOne('accounts', { account: api.sender });
+    const acct = await api.db.findOne('accounts', { account: from });
     await api.db.remove('approvals', approval);
 
     const balance = await api.db.findOneInTable('tokens', 'balances', { account: from, symbol: GOVERNANCE_TOKEN_SYMBOL });
@@ -371,8 +371,8 @@ actions.disapprove = async (payload) => {
 };
 
 const expireAllUserApprovals = async (username) => {
-  const approvals = await api.db.findOne('approvals', { from: username });
-  for (let i = 0; i <= approvals.length; i += 1) {
+  const approvals = await api.db.find('approvals', { from: username });
+  for (let i = 0; i < approvals.length; i += 1) {
     const approval = approvals[i];
     await removeApproval(approval.from, approval.to, false);
   }

--- a/contracts/witnesses.js
+++ b/contracts/witnesses.js
@@ -51,6 +51,8 @@ actions.createSSC = async () => {
 
     await api.db.insert('params', params);
   } else {
+    const params = await api.db.findOne('params', {});
+    
     // This should be removed after being deployed
     if (!params.witnessApproveExpireBlocks) {
       let offset = 0;
@@ -66,8 +68,7 @@ actions.createSSC = async () => {
       } while (accounts.length === 1000);
     }
     // End block to remove
-    
-    const params = await api.db.findOne('params', {});
+  
     params.witnessApproveExpireBlocks = WITNESS_APPROVE_EXPIRE_BLOCKS;
     await api.db.update('params', params);
   }

--- a/contracts/witnesses.js
+++ b/contracts/witnesses.js
@@ -101,6 +101,7 @@ actions.updateParams = async (payload) => {
     witnessSignaturesRequired,
     maxRoundsMissedInARow,
     maxRoundPropositionWaitingPeriod,
+    witnessApproveExpireBlocks,
   } = payload;
 
   const params = await api.db.findOne('params', {});
@@ -128,6 +129,10 @@ actions.updateParams = async (payload) => {
   }
   if (!api.assert(params.numberOfTopWitnesses + 1 === params.numberOfWitnessSlots, 'only 1 backup allowed')) {
     return;
+  }
+  if (witnessApproveExpireBlocks && Number.isInteger(witnessApproveExpireBlocks)
+    && api.assert(witnessApproveExpireBlocks > params.numberOfWitnessSlots, 'witnessApproveExpireBlocks should be greater than numberOfWitnessSlots')) {
+    params.witnessApproveExpireBlocks = witnessApproveExpireBlocks;
   }
   await api.db.update('params', params);
   if (shouldResetSchedule) {

--- a/test/witnesses.js
+++ b/test/witnesses.js
@@ -1885,7 +1885,7 @@ describe('witnesses', function () {
       });
   });
 
-  it.only('expires many votes', function (done) {
+  it('expires many votes', function (done) {
     this.timeout(120000); // 2 minutes
     new Promise(async (resolve) => {
       await fixture.setUp();
@@ -1973,8 +1973,8 @@ describe('witnesses', function () {
       assert.equal(params.round, 1);
       assert.equal(params.lastBlockRound, 7);
 
-      // generate 71 blocks
-      for (let index = 30; index < 102; index++) {
+      // generate 401 blocks
+      for (let index = 30; index < 432; index++) {
         transactions = [];
         transactions.push(new Transaction(100000001 + index, fixture.getNextTxId(), 'satoshi', 'whatever', 'whatever', ''));
 
@@ -1989,13 +1989,14 @@ describe('witnesses', function () {
         await fixture.sendBlock(block);
       }
 
-      // We should see expirations in 3 blocks, 1000 each max(1000,1000,999)
-      let expiringBlock = await fixture.database.getBlockInfo(54);
-      assert.equal(JSON.parse(expiringBlock.virtualTransactions[0].logs).events.length, 2000);
-      expiringBlock = await fixture.database.getBlockInfo(55);
-      assert.equal(JSON.parse(expiringBlock.virtualTransactions[0].logs).events.length, 2000);
-      expiringBlock = await fixture.database.getBlockInfo(56);
-      assert.equal(JSON.parse(expiringBlock.virtualTransactions[0].logs).events.length, 1998);
+      const witnessChangeBlocks = [63,83,103,123,143,163,183,203,223,243,263,283,303,323,343]; //We have an extra action in these blocks for witness change
+      // We should see expirations in multiple blocks
+      for (let i = 54; i < 353; i++){
+        let expiringBlock = await fixture.database.getBlockInfo(i);
+        assert.equal(JSON.parse(expiringBlock.virtualTransactions[0].logs).events.length, witnessChangeBlocks.includes(i) ? 21 : 20);
+      }
+      let expiringBlock = await fixture.database.getBlockInfo(353);
+      assert.equal(JSON.parse(expiringBlock.virtualTransactions[0].logs).events.length, 18);
 
       let accounts = await fixture.database.find({
         contract: 'witnesses',

--- a/test/witnesses.js
+++ b/test/witnesses.js
@@ -1887,12 +1887,11 @@ describe('witnesses', function () {
 
   it.only('expires many votes', function (done) {
     this.timeout(120000); // 2 minutes
-    if (PERFORMANCE_CHECKS_ENABLED !== true) {
-      console.log("Performace checks disabled; skipping");
-      resolve();
-    }
     new Promise(async (resolve) => {
-
+      if (PERFORMANCE_CHECKS_ENABLED !== true) {
+        console.log("Performace checks disabled; skipping");
+        resolve();
+      }
       await fixture.setUp();
       let transactions = [];
       transactions.push(new Transaction(99999999, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'contract', 'update', JSON.stringify(tokensContractPayload)));

--- a/test/witnesses.js
+++ b/test/witnesses.js
@@ -1739,7 +1739,7 @@ describe('witnesses', function () {
       });
   });
 
-  it.only('expires votes', (done) => {
+  it('expires votes', (done) => {
     new Promise(async (resolve) => {
 
       await fixture.setUp();

--- a/test/witnesses.js
+++ b/test/witnesses.js
@@ -39,13 +39,13 @@ const tokenfundsContractPayload = setupContractPayload('tokenfunds', './contract
 const nftauctionContractPayload = setupContractPayload('nftauction', './contracts/nftauction.js');
 const inflationContractPayload = setupContractPayload('inflation', './contracts/inflation.js');
 const witnessesContractPayload = setupContractPayload('witnesses', './contracts/witnesses.js',
-    (contractCode) => contractCode.replace(/NB_TOP_WITNESSES = .*;/, 'NB_TOP_WITNESSES = 4;').replace(/MAX_ROUND_PROPOSITION_WAITING_PERIOD = .*;/, 'MAX_ROUND_PROPOSITION_WAITING_PERIOD = 20;').replace(/NB_WITNESSES_SIGNATURES_REQUIRED = .*;/, 'NB_WITNESSES_SIGNATURES_REQUIRED = 3;'));
+  (contractCode) => contractCode.replace(/NB_TOP_WITNESSES = .*;/, 'NB_TOP_WITNESSES = 4;').replace(/MAX_ROUND_PROPOSITION_WAITING_PERIOD = .*;/, 'MAX_ROUND_PROPOSITION_WAITING_PERIOD = 20;').replace(/NB_WITNESSES_SIGNATURES_REQUIRED = .*;/, 'NB_WITNESSES_SIGNATURES_REQUIRED = 3;').replace(/WITNESS_APPROVE_EXPIRE_BLOCKS = .*;/, 'WITNESS_APPROVE_EXPIRE_BLOCKS = 100;'));
 
 function addGovernanceTokenTransactions(fixture, transactions, blockNumber) {
-    transactions.push(new Transaction(blockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'tokens', 'create', `{ "isSignedWithActiveKey": true,  "name": "token", "symbol": "${CONSTANTS.GOVERNANCE_TOKEN_SYMBOL}", "precision": 5, "maxSupply": "10000000", "isSignedWithActiveKey": true }`));
-    transactions.push(new Transaction(blockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'tokens', 'enableStaking', `{ "symbol": "${CONSTANTS.GOVERNANCE_TOKEN_SYMBOL}", "unstakingCooldown": 40, "numberTransactions": 4, "isSignedWithActiveKey": true }`));
-    transactions.push(new Transaction(blockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'tokens', 'enableDelegation', `{ "symbol": "${CONSTANTS.GOVERNANCE_TOKEN_SYMBOL}", "undelegationCooldown": 7, "isSignedWithActiveKey": true }`));
-    transactions.push(new Transaction(blockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'tokens', 'issue', `{ "symbol": "${CONSTANTS.GOVERNANCE_TOKEN_SYMBOL}", "to": "${CONSTANTS.HIVE_ENGINE_ACCOUNT}", "quantity": "1500000", "isSignedWithActiveKey": true }`));
+  transactions.push(new Transaction(blockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'tokens', 'create', `{ "isSignedWithActiveKey": true,  "name": "token", "symbol": "${CONSTANTS.GOVERNANCE_TOKEN_SYMBOL}", "precision": 5, "maxSupply": "10000000", "isSignedWithActiveKey": true }`));
+  transactions.push(new Transaction(blockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'tokens', 'enableStaking', `{ "symbol": "${CONSTANTS.GOVERNANCE_TOKEN_SYMBOL}", "unstakingCooldown": 40, "numberTransactions": 4, "isSignedWithActiveKey": true }`));
+  transactions.push(new Transaction(blockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'tokens', 'enableDelegation', `{ "symbol": "${CONSTANTS.GOVERNANCE_TOKEN_SYMBOL}", "undelegationCooldown": 7, "isSignedWithActiveKey": true }`));
+  transactions.push(new Transaction(blockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'tokens', 'issue', `{ "symbol": "${CONSTANTS.GOVERNANCE_TOKEN_SYMBOL}", "to": "${CONSTANTS.HIVE_ENGINE_ACCOUNT}", "quantity": "1500000", "isSignedWithActiveKey": true }`));
 }
 
 const fixture = new Fixture();
@@ -65,7 +65,7 @@ describe('witnesses', function () {
         done()
       })
   });
-  
+
   after((done) => {
     new Promise(async (resolve) => {
       await client.close();
@@ -87,16 +87,16 @@ describe('witnesses', function () {
   });
 
   afterEach((done) => {
-      // runs after each test in this block
-      new Promise(async (resolve) => {
-        await db.dropDatabase()
-        resolve();
+    // runs after each test in this block
+    new Promise(async (resolve) => {
+      await db.dropDatabase()
+      resolve();
+    })
+      .then(() => {
+        done()
       })
-        .then(() => {
-          done()
-        })
   });
-  
+
   it('registers witnesses', (done) => {
     new Promise(async (resolve) => {
       await fixture.setUp();
@@ -122,11 +122,11 @@ describe('witnesses', function () {
       await fixture.sendBlock(block);
 
       let res = await fixture.database.find({
-          contract: 'witnesses',
-          table: 'witnesses',
-          query: {
-          }
-        });
+        contract: 'witnesses',
+        table: 'witnesses',
+        query: {
+        }
+      });
 
       let witnesses = res;
 
@@ -162,11 +162,11 @@ describe('witnesses', function () {
       await fixture.sendBlock(block);
 
       res = await fixture.database.find({
-          contract: 'witnesses',
-          table: 'witnesses',
-          query: {
-          }
-        });
+        contract: 'witnesses',
+        table: 'witnesses',
+        query: {
+        }
+      });
 
       witnesses = res;
 
@@ -196,7 +196,7 @@ describe('witnesses', function () {
 
   it('approves witnesses', (done) => {
     new Promise(async (resolve) => {
-      
+
       await fixture.setUp();
 
       let transactions = [];
@@ -224,11 +224,11 @@ describe('witnesses', function () {
       await fixture.sendBlock(block);
 
       let res = await fixture.database.find({
-          contract: 'witnesses',
-          table: 'witnesses',
-          query: {
-          }
-        });
+        contract: 'witnesses',
+        table: 'witnesses',
+        query: {
+        }
+      });
 
       let witnesses = res;
 
@@ -239,12 +239,12 @@ describe('witnesses', function () {
       assert.equal(witnesses[1].approvalWeight.$numberDecimal, "100.00000");
 
       res = await fixture.database.findOne({
-          contract: 'witnesses',
-          table: 'accounts',
-          query: {
-            account: CONSTANTS.HIVE_ENGINE_ACCOUNT
-          }
-        });
+        contract: 'witnesses',
+        table: 'accounts',
+        query: {
+          account: CONSTANTS.HIVE_ENGINE_ACCOUNT
+        }
+      });
 
       let account = res;
 
@@ -252,11 +252,11 @@ describe('witnesses', function () {
       assert.equal(account.approvalWeight, "100.00000");
 
       res = await fixture.database.find({
-          contract: 'witnesses',
-          table: 'approvals',
-          query: {
-          }
-        });
+        contract: 'witnesses',
+        table: 'approvals',
+        query: {
+        }
+      });
 
       let approvals = res;
 
@@ -267,11 +267,11 @@ describe('witnesses', function () {
       assert.equal(approvals[1].to, "vitalik");
 
       res = await fixture.database.find({
-          contract: 'witnesses',
-          table: 'params',
-          query: {
-          }
-        });
+        contract: 'witnesses',
+        table: 'params',
+        query: {
+        }
+      });
 
       let params = res;
 
@@ -296,11 +296,11 @@ describe('witnesses', function () {
       await fixture.sendBlock(block);
 
       res = await fixture.database.find({
-          contract: 'witnesses',
-          table: 'witnesses',
-          query: {
-          }
-        });
+        contract: 'witnesses',
+        table: 'witnesses',
+        query: {
+        }
+      });
 
       witnesses = res;
 
@@ -314,11 +314,11 @@ describe('witnesses', function () {
       assert.equal(witnesses[2].approvalWeight.$numberDecimal, "100.00001");
 
       res = await fixture.database.find({
-          contract: 'witnesses',
-          table: 'accounts',
-          query: {
-          }
-        });
+        contract: 'witnesses',
+        table: 'accounts',
+        query: {
+        }
+      });
 
       let accounts = res;
 
@@ -331,11 +331,11 @@ describe('witnesses', function () {
       assert.equal(accounts[1].approvalWeight, "0.00001");
 
       res = await fixture.database.find({
-          contract: 'witnesses',
-          table: 'approvals',
-          query: {
-          }
-        });
+        contract: 'witnesses',
+        table: 'approvals',
+        query: {
+        }
+      });
 
       approvals = res;
 
@@ -355,11 +355,11 @@ describe('witnesses', function () {
       assert.equal(approvals[4].to, "satoshi");
 
       res = await fixture.database.find({
-          contract: 'witnesses',
-          table: 'params',
-          query: {
-          }
-        });
+        contract: 'witnesses',
+        table: 'params',
+        query: {
+        }
+      });
 
       params = res;
 
@@ -421,11 +421,11 @@ describe('witnesses', function () {
       await fixture.sendBlock(block);
 
       res = await fixture.database.find({
-          contract: 'witnesses',
-          table: 'witnesses',
-          query: {
-          }
-        });
+        contract: 'witnesses',
+        table: 'witnesses',
+        query: {
+        }
+      });
 
       witnesses = res;
 
@@ -439,11 +439,11 @@ describe('witnesses', function () {
       assert.equal(witnesses[2].approvalWeight.$numberDecimal, "100.00000");
 
       res = await fixture.database.find({
-          contract: 'witnesses',
-          table: 'accounts',
-          query: {
-          }
-        });
+        contract: 'witnesses',
+        table: 'accounts',
+        query: {
+        }
+      });
 
       let accounts = res;
 
@@ -456,12 +456,12 @@ describe('witnesses', function () {
       assert.equal(accounts[1].approvalWeight, "0.00001");
 
       res = await fixture.database.find({
-          contract: 'witnesses',
-          table: 'approvals',
-          query: {
-            to: "satoshi"
-          }
-        });
+        contract: 'witnesses',
+        table: 'approvals',
+        query: {
+          to: "satoshi"
+        }
+      });
 
       approvals = res;
 
@@ -470,11 +470,11 @@ describe('witnesses', function () {
       assert.equal(approvals.length, 1);
 
       res = await fixture.database.find({
-          contract: 'witnesses',
-          table: 'params',
-          query: {
-          }
-        });
+        contract: 'witnesses',
+        table: 'params',
+        query: {
+        }
+      });
 
       params = res;
 
@@ -495,11 +495,11 @@ describe('witnesses', function () {
       await fixture.sendBlock(block);
 
       res = await fixture.database.find({
-          contract: 'witnesses',
-          table: 'witnesses',
-          query: {
-          }
-        });
+        contract: 'witnesses',
+        table: 'witnesses',
+        query: {
+        }
+      });
 
       witnesses = res;
 
@@ -513,11 +513,11 @@ describe('witnesses', function () {
       assert.equal(witnesses[2].approvalWeight.$numberDecimal, "0.00000");
 
       res = await fixture.database.find({
-          contract: 'witnesses',
-          table: 'accounts',
-          query: {
-          }
-        });
+        contract: 'witnesses',
+        table: 'accounts',
+        query: {
+        }
+      });
 
       accounts = res;
 
@@ -530,23 +530,23 @@ describe('witnesses', function () {
       assert.equal(accounts[1].approvalWeight, "0.00001");
 
       res = await fixture.database.find({
-          contract: 'witnesses',
-          table: 'approvals',
-          query: {
-            to: "satoshi"
-          }
-        });
+        contract: 'witnesses',
+        table: 'approvals',
+        query: {
+          to: "satoshi"
+        }
+      });
 
       approvals = res;
 
       assert.equal(approvals.length, 0);
 
       res = await fixture.database.find({
-          contract: 'witnesses',
-          table: 'params',
-          query: {
-          }
-        });
+        contract: 'witnesses',
+        table: 'params',
+        query: {
+        }
+      });
 
       params = res;
 
@@ -563,7 +563,7 @@ describe('witnesses', function () {
 
   it('updates witnesses approvals when staking, unstaking, delegating and undelegating the utility token', (done) => {
     new Promise(async (resolve) => {
-      
+
       await fixture.setUp();
 
       let transactions = [];
@@ -593,11 +593,11 @@ describe('witnesses', function () {
       await fixture.sendBlock(block);
 
       let res = await fixture.database.find({
-          contract: 'witnesses',
-          table: 'witnesses',
-          query: {
-          }
-        });
+        contract: 'witnesses',
+        table: 'witnesses',
+        query: {
+        }
+      });
 
       let witnesses = res;
       assert.equal(witnesses[0].account, "dan");
@@ -607,12 +607,12 @@ describe('witnesses', function () {
       assert.equal(witnesses[1].approvalWeight.$numberDecimal, "100.00001");
 
       res = await fixture.database.findOne({
-          contract: 'witnesses',
-          table: 'accounts',
-          query: {
-            account: CONSTANTS.HIVE_ENGINE_ACCOUNT
-          }
-        });
+        contract: 'witnesses',
+        table: 'accounts',
+        query: {
+          account: CONSTANTS.HIVE_ENGINE_ACCOUNT
+        }
+      });
 
       let account = res;
 
@@ -620,11 +620,11 @@ describe('witnesses', function () {
       assert.equal(account.approvalWeight, "100.00001");
 
       res = await fixture.database.find({
-          contract: 'witnesses',
-          table: 'approvals',
-          query: {
-          }
-        });
+        contract: 'witnesses',
+        table: 'approvals',
+        query: {
+        }
+      });
 
       let approvals = res;
 
@@ -635,11 +635,11 @@ describe('witnesses', function () {
       assert.equal(approvals[1].to, "vitalik");
 
       res = await fixture.database.find({
-          contract: 'witnesses',
-          table: 'params',
-          query: {
-          }
-        });
+        contract: 'witnesses',
+        table: 'params',
+        query: {
+        }
+      });
 
       let params = res;
 
@@ -660,11 +660,11 @@ describe('witnesses', function () {
       await fixture.sendBlock(block);
 
       res = await fixture.database.find({
-          contract: 'witnesses',
-          table: 'witnesses',
-          query: {
-          }
-        });
+        contract: 'witnesses',
+        table: 'witnesses',
+        query: {
+        }
+      });
 
       witnesses = res;
 
@@ -675,11 +675,11 @@ describe('witnesses', function () {
       assert.equal(witnesses[1].approvalWeight.$numberDecimal, "100.00001");
 
       res = await fixture.database.find({
-          contract: 'witnesses',
-          table: 'accounts',
-          query: {
-          }
-        });
+        contract: 'witnesses',
+        table: 'accounts',
+        query: {
+        }
+      });
 
       let accounts = res;
 
@@ -705,11 +705,11 @@ describe('witnesses', function () {
       await fixture.sendBlock(block);
 
       res = await fixture.database.find({
-          contract: 'witnesses',
-          table: 'witnesses',
-          query: {
-          }
-        });
+        contract: 'witnesses',
+        table: 'witnesses',
+        query: {
+        }
+      });
 
       witnesses = res;
 
@@ -720,11 +720,11 @@ describe('witnesses', function () {
       assert.equal(witnesses[1].approvalWeight.$numberDecimal, "98.00001");
 
       res = await fixture.database.find({
-          contract: 'witnesses',
-          table: 'accounts',
-          query: {
-          }
-        });
+        contract: 'witnesses',
+        table: 'accounts',
+        query: {
+        }
+      });
 
       accounts = res;
 
@@ -737,11 +737,11 @@ describe('witnesses', function () {
       assert.equal(accounts[1].approvalWeight, "3.00000");
 
       res = await fixture.database.find({
-          contract: 'witnesses',
-          table: 'approvals',
-          query: {
-          }
-        });
+        contract: 'witnesses',
+        table: 'approvals',
+        query: {
+        }
+      });
 
       approvals = res;
 
@@ -755,11 +755,11 @@ describe('witnesses', function () {
       assert.equal(approvals[2].to, "dan");
 
       res = await fixture.database.find({
-          contract: 'witnesses',
-          table: 'params',
-          query: {
-          }
-        });
+        contract: 'witnesses',
+        table: 'params',
+        query: {
+        }
+      });
 
       params = res;
 
@@ -780,18 +780,18 @@ describe('witnesses', function () {
       await fixture.sendBlock(block);
 
       res = await fixture.database.find({
-          contract: 'tokens',
-          table: 'pendingUndelegations',
-          query: {
-          }
-        });
+        contract: 'tokens',
+        table: 'pendingUndelegations',
+        query: {
+        }
+      });
 
       res = await fixture.database.find({
-          contract: 'witnesses',
-          table: 'witnesses',
-          query: {
-          }
-        });
+        contract: 'witnesses',
+        table: 'witnesses',
+        query: {
+        }
+      });
 
       witnesses = res;
 
@@ -802,11 +802,11 @@ describe('witnesses', function () {
       assert.equal(witnesses[1].approvalWeight.$numberDecimal, "98.00001");
 
       res = await fixture.database.find({
-          contract: 'witnesses',
-          table: 'accounts',
-          query: {
-          }
-        });
+        contract: 'witnesses',
+        table: 'accounts',
+        query: {
+        }
+      });
 
       accounts = res;
 
@@ -819,11 +819,11 @@ describe('witnesses', function () {
       assert.equal(accounts[1].approvalWeight, "1.00000");
 
       res = await fixture.database.find({
-          contract: 'witnesses',
-          table: 'approvals',
-          query: {
-          }
-        });
+        contract: 'witnesses',
+        table: 'approvals',
+        query: {
+        }
+      });
 
       approvals = res;
 
@@ -837,11 +837,11 @@ describe('witnesses', function () {
       assert.equal(approvals[2].to, "dan");
 
       res = await fixture.database.find({
-          contract: 'witnesses',
-          table: 'params',
-          query: {
-          }
-        });
+        contract: 'witnesses',
+        table: 'params',
+        query: {
+        }
+      });
 
       params = res;
 
@@ -862,11 +862,11 @@ describe('witnesses', function () {
       await fixture.sendBlock(block);
 
       res = await fixture.database.find({
-          contract: 'witnesses',
-          table: 'witnesses',
-          query: {
-          }
-        });
+        contract: 'witnesses',
+        table: 'witnesses',
+        query: {
+        }
+      });
 
       witnesses = res;
 
@@ -877,11 +877,11 @@ describe('witnesses', function () {
       assert.equal(witnesses[1].approvalWeight.$numberDecimal, "100.00001");
 
       res = await fixture.database.find({
-          contract: 'witnesses',
-          table: 'accounts',
-          query: {
-          }
-        });
+        contract: 'witnesses',
+        table: 'accounts',
+        query: {
+        }
+      });
 
       accounts = res;
 
@@ -894,11 +894,11 @@ describe('witnesses', function () {
       assert.equal(accounts[1].approvalWeight, "1.00000");
 
       res = await fixture.database.find({
-          contract: 'witnesses',
-          table: 'approvals',
-          query: {
-          }
-        });
+        contract: 'witnesses',
+        table: 'approvals',
+        query: {
+        }
+      });
 
       approvals = res;
 
@@ -912,11 +912,11 @@ describe('witnesses', function () {
       assert.equal(approvals[2].to, "dan");
 
       res = await fixture.database.find({
-          contract: 'witnesses',
-          table: 'params',
-          query: {
-          }
-        });
+        contract: 'witnesses',
+        table: 'params',
+        query: {
+        }
+      });
 
       params = res;
 
@@ -937,11 +937,11 @@ describe('witnesses', function () {
       await fixture.sendBlock(block);
 
       res = await fixture.database.find({
-          contract: 'witnesses',
-          table: 'witnesses',
-          query: {
-          }
-        });
+        contract: 'witnesses',
+        table: 'witnesses',
+        query: {
+        }
+      });
 
       witnesses = res;
 
@@ -952,11 +952,11 @@ describe('witnesses', function () {
       assert.equal(witnesses[1].approvalWeight.$numberDecimal, "100.00001");
 
       res = await fixture.database.find({
-          contract: 'witnesses',
-          table: 'accounts',
-          query: {
-          }
-        });
+        contract: 'witnesses',
+        table: 'accounts',
+        query: {
+        }
+      });
 
       accounts = res;
 
@@ -969,11 +969,11 @@ describe('witnesses', function () {
       assert.equal(accounts[1].approvalWeight, "0.75000");
 
       res = await fixture.database.find({
-          contract: 'witnesses',
-          table: 'approvals',
-          query: {
-          }
-        });
+        contract: 'witnesses',
+        table: 'approvals',
+        query: {
+        }
+      });
 
       approvals = res;
 
@@ -987,11 +987,11 @@ describe('witnesses', function () {
       assert.equal(approvals[2].to, "dan");
 
       res = await fixture.database.find({
-          contract: 'witnesses',
-          table: 'params',
-          query: {
-          }
-        });
+        contract: 'witnesses',
+        table: 'params',
+        query: {
+        }
+      });
 
       params = res;
 
@@ -1012,11 +1012,11 @@ describe('witnesses', function () {
       await fixture.sendBlock(block);
 
       res = await fixture.database.find({
-          contract: 'witnesses',
-          table: 'witnesses',
-          query: {
-          }
-        });
+        contract: 'witnesses',
+        table: 'witnesses',
+        query: {
+        }
+      });
 
       witnesses = res;
 
@@ -1027,11 +1027,11 @@ describe('witnesses', function () {
       assert.equal(witnesses[1].approvalWeight.$numberDecimal, "100.00001");
 
       res = await fixture.database.find({
-          contract: 'witnesses',
-          table: 'accounts',
-          query: {
-          }
-        });
+        contract: 'witnesses',
+        table: 'accounts',
+        query: {
+        }
+      });
 
       accounts = res;
 
@@ -1044,11 +1044,11 @@ describe('witnesses', function () {
       assert.equal(accounts[1].approvalWeight, "0.25000");
 
       res = await fixture.database.find({
-          contract: 'witnesses',
-          table: 'approvals',
-          query: {
-          }
-        });
+        contract: 'witnesses',
+        table: 'approvals',
+        query: {
+        }
+      });
 
       approvals = res;
 
@@ -1062,17 +1062,17 @@ describe('witnesses', function () {
       assert.equal(approvals[2].to, "dan");
 
       res = await fixture.database.find({
-          contract: 'witnesses',
-          table: 'params',
-          query: {
-          }
-        });
+        contract: 'witnesses',
+        table: 'params',
+        query: {
+        }
+      });
 
       params = res;
 
       assert.equal(params[0].numberOfApprovedWitnesses, 2);
       assert.equal(params[0].totalApprovalWeight, "200.25002");
-      
+
       resolve();
     })
       .then(() => {
@@ -1083,7 +1083,7 @@ describe('witnesses', function () {
 
   it('schedules witnesses', (done) => {
     new Promise(async (resolve) => {
-      
+
       await fixture.setUp();
       let transactions = [];
       transactions.push(new Transaction(37899128, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'contract', 'update', JSON.stringify(tokensContractPayload)));
@@ -1131,12 +1131,12 @@ describe('witnesses', function () {
       await tableAsserts.assertNoErrorInLastBlock();
 
       let res = await fixture.database.find({
-          contract: 'witnesses',
-          table: 'schedules',
-          query: {
-            
-          }
-        });
+        contract: 'witnesses',
+        table: 'schedules',
+        query: {
+
+        }
+      });
 
       let schedule = res;
       console.log(schedule);
@@ -1162,12 +1162,12 @@ describe('witnesses', function () {
       assert.equal(schedule[4].round, 1);
 
       res = await fixture.database.findOne({
-          contract: 'witnesses',
-          table: 'params',
-          query: {
-            
-          }
-        });
+        contract: 'witnesses',
+        table: 'params',
+        query: {
+
+        }
+      });
 
       let params = res;
 
@@ -1189,7 +1189,7 @@ describe('witnesses', function () {
 
   it('verifies a block with staked pay', (done) => {
     new Promise(async (resolve) => {
-      
+
       await fixture.setUp();
       let transactions = [];
       transactions.push(new Transaction(37899120, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'contract', 'update', JSON.stringify(tokensContractPayload)));
@@ -1266,10 +1266,10 @@ describe('witnesses', function () {
       await tableAsserts.assertNoErrorInLastBlock();
 
       let params = await fixture.database.findOne({
-          contract: 'witnesses',
-          table: 'params',
-          query: {}
-        });
+        contract: 'witnesses',
+        table: 'params',
+        query: {}
+      });
 
       assert.equal(params.numberOfWitnessSlots, 21);
       assert.equal(params.witnessSignaturesRequired, 14);
@@ -1305,14 +1305,14 @@ describe('witnesses', function () {
         }
         blockNum += 1;
       }
-      
+
       res = await fixture.database.find({
-          contract: 'witnesses',
-          table: 'schedules',
-          query: {
-            
-          }
-        });
+        contract: 'witnesses',
+        table: 'schedules',
+        query: {
+
+        }
+      });
 
       let schedules = res;
       assert(schedules.length > 0);
@@ -1361,11 +1361,11 @@ describe('witnesses', function () {
         assert.equal(blockFromNode.signingKey, wif.createPublic().toString());
         assert.equal(blockFromNode.roundSignature, signatures[signatures.length - 1][1]);
         blockNum += 1;
-        i +=1;
+        i += 1;
       }
 
       for (i = 0; i < schedules.length; i += 1) {
-        await tableAsserts.assertUserBalances({ account: schedules[i].witness, symbol: CONSTANTS.UTILITY_TOKEN_SYMBOL, balance: "0", stake: "0.01902586"});
+        await tableAsserts.assertUserBalances({ account: schedules[i].witness, symbol: CONSTANTS.UTILITY_TOKEN_SYMBOL, balance: "0", stake: "0.01902586" });
       }
 
       resolve();
@@ -1378,7 +1378,7 @@ describe('witnesses', function () {
 
   it('generates a new schedule once the current one is completed', (done) => {
     new Promise(async (resolve) => {
-      
+
       await fixture.setUp();
       let transactions = [];
       let refBlockNumber = fixture.getNextRefBlockNumber();
@@ -1440,15 +1440,15 @@ describe('witnesses', function () {
         };
 
         await fixture.sendBlock(block);
-      } 
+      }
 
       let params = await fixture.database.findOne({
-          contract: 'witnesses',
-          table: 'params',
-          query: {}
-        });
+        contract: 'witnesses',
+        table: 'params',
+        query: {}
+      });
 
-        console.log(params);
+      console.log(params);
 
       let blockNum = params.lastVerifiedBlockNumber + 1;
       const endBlockRound = params.lastBlockRound;
@@ -1465,12 +1465,12 @@ describe('witnesses', function () {
         }
         blockNum += 1;
       }
-      
+
       const schedule = await fixture.database.find({
-          contract: 'witnesses',
-          table: 'schedules',
-          query: {}
-        });
+        contract: 'witnesses',
+        table: 'schedules',
+        query: {}
+      });
 
       const signatures = [];
       schedule.forEach(scheduleItem => {
@@ -1485,7 +1485,7 @@ describe('witnesses', function () {
         signatures,
         isSignedWithActiveKey: true,
       };
-        console.log(json);
+      console.log(json);
 
       transactions = [];
       refBlockNumber = fixture.getNextRefBlockNumber();
@@ -1503,10 +1503,10 @@ describe('witnesses', function () {
       await tableAsserts.assertNoErrorInLastBlock();
 
       const newSchedule = await fixture.database.find({
-          contract: 'witnesses',
-          table: 'schedules',
-          query: {}
-        });
+        contract: 'witnesses',
+        table: 'schedules',
+        query: {}
+      });
 
       assert.equal(newSchedule.length, schedule.length);
       for (let i = 0; i < newSchedule.length; i += 1) {
@@ -1516,10 +1516,10 @@ describe('witnesses', function () {
       assert(newSchedule[0].witness !== schedule[schedule.length - 1].witness);
 
       params = await fixture.database.findOne({
-          contract: 'witnesses',
-          table: 'params',
-          query: {}
-        });
+        contract: 'witnesses',
+        table: 'params',
+        query: {}
+      });
 
       assert.equal(params.totalApprovalWeight, '3000.00000');
       assert.equal(params.numberOfApprovedWitnesses, 30);
@@ -1528,7 +1528,7 @@ describe('witnesses', function () {
       assert(params.lastWitnesses.includes(newSchedule[newSchedule.length - 1].witness));
       assert.equal(params.round, 2);
       assert.equal(params.lastBlockRound, 11);
-      
+
       resolve();
     })
       .then(() => {
@@ -1539,7 +1539,7 @@ describe('witnesses', function () {
 
   it('changes the current witness if it has not validated a round in time', (done) => {
     new Promise(async (resolve) => {
-      
+
       await fixture.setUp();
       let transactions = [];
       transactions.push(new Transaction(99999999, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'contract', 'update', JSON.stringify(tokensContractPayload)));
@@ -1584,12 +1584,12 @@ describe('witnesses', function () {
       await fixture.sendBlock(block);
 
       let res = await fixture.database.findOne({
-          contract: 'witnesses',
-          table: 'params',
-          query: {
-            
-          }
-        });
+        contract: 'witnesses',
+        table: 'params',
+        query: {
+
+        }
+      });
 
       let params = res;
 
@@ -1617,22 +1617,22 @@ describe('witnesses', function () {
         await fixture.sendBlock(block);
       }
 
-        res = await fixture.database.findOne({
-          contract: 'witnesses',
-          table: 'params',
-          query: {
-            
-          }
-        });
+      res = await fixture.database.findOne({
+        contract: 'witnesses',
+        table: 'params',
+        query: {
+
+        }
+      });
 
       params = res;
 
-      assert.equal(JSON.stringify(params), '{"_id":1,"totalApprovalWeight":"3000.00000","numberOfApprovedWitnesses":30,"lastVerifiedBlockNumber":1,"round":1,"lastBlockRound":6,"currentWitness":"witness10","blockNumberWitnessChange":42,"lastWitnesses":["witness6","witness10"],"numberOfApprovalsPerAccount":30,"numberOfTopWitnesses":4,"numberOfWitnessSlots":5,"witnessSignaturesRequired":3,"maxRoundsMissedInARow":3,"maxRoundPropositionWaitingPeriod":20,"witnessApproveExpireBlocks":5184000}');
+      assert.equal(JSON.stringify(params), '{"_id":1,"totalApprovalWeight":"3000.00000","numberOfApprovedWitnesses":30,"lastVerifiedBlockNumber":1,"round":1,"lastBlockRound":6,"currentWitness":"witness10","blockNumberWitnessChange":42,"lastWitnesses":["witness6","witness10"],"numberOfApprovalsPerAccount":30,"numberOfTopWitnesses":4,"numberOfWitnessSlots":5,"witnessSignaturesRequired":3,"maxRoundsMissedInARow":3,"maxRoundPropositionWaitingPeriod":20,"witnessApproveExpireBlocks":100}');
 
       let schedule = await fixture.database.find({
-          contract: 'witnesses',
-          table: 'schedules',
-          query: {}
+        contract: 'witnesses',
+        table: 'schedules',
+        query: {}
       });
 
       assert.equal(JSON.stringify(schedule), '[{"_id":1,"witness":"witness8","blockNumber":2,"round":1},{"_id":2,"witness":"witness7","blockNumber":3,"round":1},{"_id":3,"witness":"witness9","blockNumber":4,"round":1},{"_id":4,"witness":"witness5","blockNumber":5,"round":1},{"_id":5,"witness":"witness10","blockNumber":6,"round":1}]');
@@ -1647,7 +1647,7 @@ describe('witnesses', function () {
 
   it('update params', (done) => {
     new Promise(async (resolve) => {
-      
+
       await fixture.setUp();
       let transactions = [];
       let refBlockNumber = fixture.getNextRefBlockNumber();
@@ -1672,12 +1672,12 @@ describe('witnesses', function () {
       await tableAsserts.assertNoErrorInLastBlock();
 
       let params = await fixture.database.findOne({
-          contract: 'witnesses',
-          table: 'params',
-          query: {}
-        });
+        contract: 'witnesses',
+        table: 'params',
+        query: {}
+      });
 
-      assert.equal(JSON.stringify(params), '{"_id":1,"totalApprovalWeight":"0","numberOfApprovedWitnesses":0,"lastVerifiedBlockNumber":0,"round":0,"lastBlockRound":0,"currentWitness":null,"blockNumberWitnessChange":0,"lastWitnesses":[],"numberOfApprovalsPerAccount":30,"numberOfTopWitnesses":4,"numberOfWitnessSlots":5,"witnessSignaturesRequired":3,"maxRoundsMissedInARow":3,"maxRoundPropositionWaitingPeriod":20,"witnessApproveExpireBlocks":5184000}');
+      assert.equal(JSON.stringify(params), '{"_id":1,"totalApprovalWeight":"0","numberOfApprovedWitnesses":0,"lastVerifiedBlockNumber":0,"round":0,"lastBlockRound":0,"currentWitness":null,"blockNumberWitnessChange":0,"lastWitnesses":[],"numberOfApprovalsPerAccount":30,"numberOfTopWitnesses":4,"numberOfWitnessSlots":5,"witnessSignaturesRequired":3,"maxRoundsMissedInARow":3,"maxRoundPropositionWaitingPeriod":20,"witnessApproveExpireBlocks":100}');
 
       transactions = [];
       refBlockNumber = fixture.getNextRefBlockNumber();
@@ -1695,12 +1695,12 @@ describe('witnesses', function () {
       await tableAsserts.assertNoErrorInLastBlock();
 
       params = await fixture.database.findOne({
-          contract: 'witnesses',
-          table: 'params',
-          query: {}
-        });
+        contract: 'witnesses',
+        table: 'params',
+        query: {}
+      });
 
-      const paramsString = '{"_id":1,"totalApprovalWeight":"0","numberOfApprovedWitnesses":0,"lastVerifiedBlockNumber":0,"round":0,"lastBlockRound":0,"currentWitness":null,"blockNumberWitnessChange":0,"lastWitnesses":[],"numberOfApprovalsPerAccount":31,"numberOfTopWitnesses":5,"numberOfWitnessSlots":6,"witnessSignaturesRequired":16,"maxRoundsMissedInARow":4,"maxRoundPropositionWaitingPeriod":21,"witnessApproveExpireBlocks":5184000}';
+      const paramsString = '{"_id":1,"totalApprovalWeight":"0","numberOfApprovedWitnesses":0,"lastVerifiedBlockNumber":0,"round":0,"lastBlockRound":0,"currentWitness":null,"blockNumberWitnessChange":0,"lastWitnesses":[],"numberOfApprovalsPerAccount":31,"numberOfTopWitnesses":5,"numberOfWitnessSlots":6,"witnessSignaturesRequired":16,"maxRoundsMissedInARow":4,"maxRoundPropositionWaitingPeriod":21,"witnessApproveExpireBlocks":100}';
       assert.equal(JSON.stringify(params), paramsString);
 
       // Verify 1 backup witness condition in setting
@@ -1723,10 +1723,10 @@ describe('witnesses', function () {
       assertError(txs[0], 'only 1 backup allowed');
 
       params = await fixture.database.findOne({
-          contract: 'witnesses',
-          table: 'params',
-          query: {}
-        });
+        contract: 'witnesses',
+        table: 'params',
+        query: {}
+      });
 
       // unchanged from above
       assert.equal(JSON.stringify(params), paramsString);

--- a/test/witnesses.js
+++ b/test/witnesses.js
@@ -1831,7 +1831,7 @@ describe('witnesses', function () {
       });
 
       for (const approver of accounts) {
-        assert.equal(approver.approvalExpired, true);
+        assert.equal(approver.approvals, 0);
       }
 
 

--- a/test/witnesses.js
+++ b/test/witnesses.js
@@ -1888,11 +1888,11 @@ describe('witnesses', function () {
   it.only('expires many votes', function (done) {
     this.timeout(120000); // 2 minutes
     new Promise(async (resolve) => {
+      await fixture.setUp();
       if (PERFORMANCE_CHECKS_ENABLED !== true) {
         console.log("Performace checks disabled; skipping");
         resolve();
       }
-      await fixture.setUp();
       let transactions = [];
       transactions.push(new Transaction(99999999, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'contract', 'update', JSON.stringify(tokensContractPayload)));
       transactions.push(new Transaction(99999999, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'contract', 'deploy', JSON.stringify(miningContractPayload)));

--- a/test/witnesses.js
+++ b/test/witnesses.js
@@ -1819,7 +1819,7 @@ describe('witnesses', function () {
         await fixture.sendBlock(block);
       }
 
-      const expiringBlock = await fixture.database.getBlockInfo(62); // The block with the expiring actions
+      const expiringBlock = await fixture.database.getBlockInfo(53); // The block with the expiring actions
       assert.equal(JSON.stringify(JSON.parse(expiringBlock.virtualTransactions[0].logs).events[30].data), '{"account":"hive-engine"}')
 
       let accounts = await fixture.database.find({

--- a/test/witnesses.js
+++ b/test/witnesses.js
@@ -1627,7 +1627,7 @@ describe('witnesses', function () {
 
       params = res;
 
-      assert.equal(JSON.stringify(params), '{"_id":1,"totalApprovalWeight":"3000.00000","numberOfApprovedWitnesses":30,"lastVerifiedBlockNumber":1,"round":1,"lastBlockRound":6,"currentWitness":"witness10","blockNumberWitnessChange":42,"lastWitnesses":["witness6","witness10"],"numberOfApprovalsPerAccount":30,"numberOfTopWitnesses":4,"numberOfWitnessSlots":5,"witnessSignaturesRequired":3,"maxRoundsMissedInARow":3,"maxRoundPropositionWaitingPeriod":20}');
+      assert.equal(JSON.stringify(params), '{"_id":1,"totalApprovalWeight":"3000.00000","numberOfApprovedWitnesses":30,"lastVerifiedBlockNumber":1,"round":1,"lastBlockRound":6,"currentWitness":"witness10","blockNumberWitnessChange":42,"lastWitnesses":["witness6","witness10"],"numberOfApprovalsPerAccount":30,"numberOfTopWitnesses":4,"numberOfWitnessSlots":5,"witnessSignaturesRequired":3,"maxRoundsMissedInARow":3,"maxRoundPropositionWaitingPeriod":20,"witnessApproveExpireBlocks":5184000}');
 
       let schedule = await fixture.database.find({
           contract: 'witnesses',
@@ -1677,7 +1677,7 @@ describe('witnesses', function () {
           query: {}
         });
 
-      assert.equal(JSON.stringify(params), '{"_id":1,"totalApprovalWeight":"0","numberOfApprovedWitnesses":0,"lastVerifiedBlockNumber":0,"round":0,"lastBlockRound":0,"currentWitness":null,"blockNumberWitnessChange":0,"lastWitnesses":[],"numberOfApprovalsPerAccount":30,"numberOfTopWitnesses":4,"numberOfWitnessSlots":5,"witnessSignaturesRequired":3,"maxRoundsMissedInARow":3,"maxRoundPropositionWaitingPeriod":20}');
+      assert.equal(JSON.stringify(params), '{"_id":1,"totalApprovalWeight":"0","numberOfApprovedWitnesses":0,"lastVerifiedBlockNumber":0,"round":0,"lastBlockRound":0,"currentWitness":null,"blockNumberWitnessChange":0,"lastWitnesses":[],"numberOfApprovalsPerAccount":30,"numberOfTopWitnesses":4,"numberOfWitnessSlots":5,"witnessSignaturesRequired":3,"maxRoundsMissedInARow":3,"maxRoundPropositionWaitingPeriod":20,"witnessApproveExpireBlocks":5184000}');
 
       transactions = [];
       refBlockNumber = fixture.getNextRefBlockNumber();
@@ -1700,7 +1700,7 @@ describe('witnesses', function () {
           query: {}
         });
 
-      const paramsString = '{"_id":1,"totalApprovalWeight":"0","numberOfApprovedWitnesses":0,"lastVerifiedBlockNumber":0,"round":0,"lastBlockRound":0,"currentWitness":null,"blockNumberWitnessChange":0,"lastWitnesses":[],"numberOfApprovalsPerAccount":31,"numberOfTopWitnesses":5,"numberOfWitnessSlots":6,"witnessSignaturesRequired":16,"maxRoundsMissedInARow":4,"maxRoundPropositionWaitingPeriod":21}';
+      const paramsString = '{"_id":1,"totalApprovalWeight":"0","numberOfApprovedWitnesses":0,"lastVerifiedBlockNumber":0,"round":0,"lastBlockRound":0,"currentWitness":null,"blockNumberWitnessChange":0,"lastWitnesses":[],"numberOfApprovalsPerAccount":31,"numberOfTopWitnesses":5,"numberOfWitnessSlots":6,"witnessSignaturesRequired":16,"maxRoundsMissedInARow":4,"maxRoundPropositionWaitingPeriod":21,"witnessApproveExpireBlocks":5184000}';
       assert.equal(JSON.stringify(params), paramsString);
 
       // Verify 1 backup witness condition in setting


### PR DESCRIPTION
Expires witness approval after 5184000 blocks(approximately 180 days) of an account that hasn't made any witness approval/disapproval action. Also adds emits to successful approvals/disapprovals.

While testing this PR on the mirrornet, it was observed that witness approvals could go into the negatives when other contracts weren't properly deployed. A check has been added to ensure that unapprovals don't take them below 0.

Todo:
- [x]  Add Tests
- [x] Manual Tests