### PR TITLE
Get Block Range API 

### DIFF
--- a/config.json
+++ b/config.json
@@ -22,7 +22,11 @@
     "rpcConfig" : {
         "maxLimit" : 1000,
         "maxOffset" : -1,
-        "logRequests" : false
+        "logRequests" : false,
+        "disabledMethods" : {
+            "blockchain" : ["getBlockRangeInfo"],
+            "contracts" : []
+        }
     },
     "rpcWebsockets" : {
         "enabled" : true,

--- a/libs/Database.js
+++ b/libs/Database.js
@@ -302,6 +302,19 @@ class Database {
     }
   }
 
+  async getBlockRangeInfo(startBlockNumber, count) {
+    try {
+      const blocks = typeof startBlockNumber === 'number' && Number.isInteger(startBlockNumber) && typeof count === 'number' && Number.isInteger(count) 
+        ? await this.chain.find({ _id: { $gte :  startBlockNumber, $lt : startBlockNumber + count } }, { limit: 1000, session: this.session, sort: ['_id', 'asc'] }).toArray()
+        : null;
+      return EJSON.serialize(blocks);
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      log.error(error);
+      return null;
+    }
+  }
+
   /**
    * Mark a block as verified by a witness
    * @param {Integer} blockNumber block umber to mark verified

--- a/plugins/JsonRPCServer.js
+++ b/plugins/JsonRPCServer.js
@@ -167,7 +167,7 @@ function blockchainRPC() {
     },
   };
   for (const method in methods) {
-    if (config.rpcConfig.disabledMethods?.blockchain?.includes(method)) {
+    if (config.rpcConfig.disabledMethods?.blockchain?.includes(method) && method !== 'getStatus') {
       methods[method] = (args, callback) => {
         callback({
           code: 400,

--- a/plugins/JsonRPCServer.js
+++ b/plugins/JsonRPCServer.js
@@ -106,6 +106,30 @@ function blockchainRPC() {
         callback(error, null);
       }
     },
+    getBlockRangeInfo: async (args, callback) => {
+      try {
+        const { startBlockNumber, count } = args;
+
+        if (!Number.isInteger(startBlockNumber)) {
+          callback({
+            code: 400,
+            message: 'missing or wrong parameters: blockNumber is required',
+          }, null);
+          return;
+        }
+        if (!Number.isInteger(count) || count > 1000) {
+          callback({
+            code: 400,
+            message: 'missing or wrong parameters: count is required',
+          }, null);
+          return;
+        }
+        const blocks = await database.getBlockRangeInfo(startBlockNumber, count);
+        callback(null, blocks);
+      } catch (error) {
+        callback(error, null);
+      }
+    },
     getTransactionInfo: async (args, callback) => {
       try {
         const { txid } = args;
@@ -238,10 +262,10 @@ function contractsRPC() {
 
 function dualRPC() {
   const methods = {};
-  for (const method in jayson.server(blockchainRPC())._methods){
+  for (const method in jayson.server(blockchainRPC())._methods) {
     methods['blockchain.' + method] = jayson.server(blockchainRPC())._methods[method]
   }
-  for (const method in jayson.server(contractsRPC())._methods){
+  for (const method in jayson.server(contractsRPC())._methods) {
     methods['contracts.' + method] = jayson.server(contractsRPC())._methods[method]
   }
   return methods
@@ -286,7 +310,7 @@ const init = async (conf, callback) => {
     });
 
 
-  if (rpcWebsockets.enabled){
+  if (rpcWebsockets.enabled) {
     const wssServer = new jayson.Server(dualRPC());
 
     wssServer.websocket({

--- a/plugins/JsonRPCServer.js
+++ b/plugins/JsonRPCServer.js
@@ -80,7 +80,7 @@ async function generateStatus() {
 }
 
 function blockchainRPC() {
-  return {
+  let methods = {
     getLatestBlockInfo: async (args, callback) => {
       try {
         const lastestBlock = await database.getLatestBlockInfo();
@@ -156,10 +156,21 @@ function blockchainRPC() {
       }
     },
   };
+  for (const method in methods) {
+    if (config.rpcConfig.disabledMethods?.blockchain?.includes(method)) {
+      methods[method] = (args, callback) => {
+        callback({
+          code: 400,
+          message: `method blockchain.${method} is disabled`,
+        }, null);
+      }
+    }
+  }
+  return methods;
 }
 
 function contractsRPC() {
-  return {
+  let methods = {
     getContract: async (args, callback) => {
       try {
         const { name } = args;
@@ -258,6 +269,17 @@ function contractsRPC() {
       }
     },
   };
+  for (const method in methods) {
+    if (config.rpcConfig.disabledMethod?.contracts?.includes(method)) {
+      methods[method] = (args, callback) => {
+        callback({
+          code: 400,
+          message: `method contracts.${method} is disabled`,
+        }, null);
+      }
+    }
+  }
+  return methods;
 }
 
 function dualRPC() {

--- a/plugins/JsonRPCServer.js
+++ b/plugins/JsonRPCServer.js
@@ -270,7 +270,7 @@ function contractsRPC() {
     },
   };
   for (const method in methods) {
-    if (config.rpcConfig.disabledMethod?.contracts?.includes(method)) {
+    if (config.rpcConfig.disabledMethods?.contracts?.includes(method)) {
       methods[method] = (args, callback) => {
         callback({
           code: 400,

--- a/plugins/JsonRPCServer.js
+++ b/plugins/JsonRPCServer.js
@@ -55,6 +55,9 @@ async function generateStatus() {
       // get the ssc chain id from config
       result.chainId = config.chainId;
 
+      //get the disabled methods from config
+      result.disabledMethods = config.rpcConfig.disabledMethods;
+
       // get light node config of the SSC node
       result.lightNode = config.lightNode;
       if (config.lightNode) {
@@ -117,10 +120,17 @@ function blockchainRPC() {
           }, null);
           return;
         }
-        if (!Number.isInteger(count) || count > 1000) {
+        if (!Number.isInteger(count)) {
           callback({
             code: 400,
             message: 'missing or wrong parameters: count is required',
+          }, null);
+          return;
+        }
+        if ( count > 1000){
+          callback({
+            code: 400,
+            message: 'count can not be over 1000',
           }, null);
           return;
         }


### PR DESCRIPTION
Allows for getting information on blocks in a range with a single call. 

This is a very heavy api and should not be enabled on public nodes. To make sure this doesn't happen, a config feature has been added to allow disabling certain RPC methods. The default config disables the new method.