### PR TITLE
Fix error messages, Fix 1k limit

### DIFF
--- a/libs/Database.js
+++ b/libs/Database.js
@@ -4,6 +4,7 @@ const SHA256 = require('crypto-js/sha256');
 const enchex = require('crypto-js/enc-hex');
 const log = require('loglevel');
 const validator = require('validator');
+const config = require('../config.json');
 const { MongoClient } = require('mongodb');
 const { EJSON } = require('bson');
 const { CONSTANTS } = require('../libs/Constants');
@@ -577,9 +578,10 @@ class Database {
    * @param {Integer} limit limit the number of records to retrieve
    * @param {Integer} offset offset applied to the records set
    * @param {Array<Object>} indexes array of index definitions { index: string, descending: boolean }
+   * @param {Boolean} fromRPC if the call came from RPC
    * @returns {Array<Object>} returns an array of objects if records found, an empty array otherwise
    */
-  async find(payload) {
+  async find(payload, fromRPC = false) {
     try {
       const {
         contract,
@@ -608,7 +610,7 @@ class Database {
               && el.descending !== undefined && typeof el.descending === 'boolean')))
         && Number.isInteger(lim)
         && Number.isInteger(off)
-        && lim > 0 && lim <= 1000
+        && lim > 0 && lim <= fromRPC ? config.rpcConfig.maxLimit : 1000 // If the request came from the RPC, we use the max limit for that, otherwise we use 1000 since this is used internally too
         && off >= 0) {
         const finalTableName = `${contract}_${table}`;
         const contractInDb = await this.findContract({ name: contract });

--- a/plugins/JsonRPCServer.js
+++ b/plugins/JsonRPCServer.js
@@ -116,7 +116,7 @@ function blockchainRPC() {
         if (!Number.isInteger(startBlockNumber)) {
           callback({
             code: 400,
-            message: 'missing or wrong parameters: blockNumber is required',
+            message: 'missing or wrong parameters: startBlockNumber is required',
           }, null);
           return;
         }
@@ -191,7 +191,7 @@ function contractsRPC() {
         } else {
           callback({
             code: 400,
-            message: 'missing or wrong parameters: contract is required',
+            message: 'missing or wrong parameters: name is required',
           }, null);
         }
       } catch (error) {
@@ -216,7 +216,7 @@ function contractsRPC() {
         } else {
           callback({
             code: 400,
-            message: 'missing or wrong parameters: contract and tableName are required',
+            message: 'missing or wrong parameters: contract, table and query are required',
           }, null);
         }
       } catch (error) {
@@ -265,13 +265,13 @@ function contractsRPC() {
             limit: lim,
             offset: off,
             indexes: ind,
-          });
+          }, true);
 
           callback(null, result);
         } else {
           callback({
             code: 400,
-            message: 'missing or wrong parameters: contract and tableName are required',
+            message: 'missing or wrong parameters: contract, table and query are required',
           }, null);
         }
       } catch (error) {
@@ -292,7 +292,7 @@ function contractsRPC() {
   return methods;
 }
 
-function dualRPC() {
+function multiRPC() {
   const methods = {};
   for (const method in jayson.server(blockchainRPC())._methods) {
     methods['blockchain.' + method] = jayson.server(blockchainRPC())._methods[method]
@@ -325,7 +325,7 @@ const init = async (conf, callback) => {
   }
   serverRPC.post('/blockchain', jayson.server(blockchainRPC()).middleware());
   serverRPC.post('/contracts', jayson.server(contractsRPC()).middleware());
-  serverRPC.post('/', jayson.server(dualRPC()).middleware());
+  serverRPC.post('/', jayson.server(multiRPC()).middleware());
   serverRPC.get('/', async (_, res) => {
     try {
       const status = await generateStatus();
@@ -343,7 +343,7 @@ const init = async (conf, callback) => {
 
 
   if (rpcWebsockets.enabled) {
-    const wssServer = new jayson.Server(dualRPC());
+    const wssServer = new jayson.Server(multiRPC());
 
     wssServer.websocket({
       port: rpcWebsockets.port,


### PR DESCRIPTION
This PR respects the maxLimit as defined in the rpcConfig for what the max limit should be for RPC calls(it keeps 1000 for internal calls from contracts) rather than limiting it to 1000. This also modifies some of the error messages to use the proper missing/incorrect param name.