### PR TITLE
Restore default witness_action.js behaviour

### DIFF
--- a/witness_action.js
+++ b/witness_action.js
@@ -21,11 +21,11 @@ const extP2PPort = Number(String(process.env.P2PPORT)) || p2pPort;
 program
   .option('-v, --verify', 'verify transaction on hive-engine', false)
   .option('-e, --engineNode [url]', 'verify with given hive-engine node', 'https://engine.rishipanthee.com')
-  .option('-s, --skipDiverganceCheck', 'skips divergance check', false)
+  .option('-d, --diverganceCheck', 'check for divergance against the given hive-engine node', false)
   .parse(process.argv);
 
 let { engineNode } = program;
-const { verify, skipDiverganceCheck } = program;
+const { verify, diverganceCheck } = program;
 
 engineNode = engineNode.replace(/\/$/, '');
 
@@ -103,7 +103,7 @@ program
 program
   .command('register')
   .action(() => {
-    if (!skipDiverganceCheck) {
+    if (diverganceCheck) {
       exec(`node find_divergent_block.js -h -n ${engineNode}`).on('exit', (code) => {
         if (code != 0) {
           // eslint-disable-next-line no-console


### PR DESCRIPTION
Up for **discussion** but, in my view we should not force checking divergence by default against anyone, as that might introduce unwanted misunderstanding about what means to check for divergence against a node.

The option is very helpful and one can still check for divergence upon using the option against specific nodes. But because many might not even check this property, defaulting to a specific node might introduce a targeted behavior without many noticing.