### PR TITLE
Set rpc query maxTimeMS

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -26,6 +26,7 @@
         "maxLimit" : 1000,
         "maxOffset" : -1,
         "maxBatchLength" : 1,
+        "maxDBTimeMS" : 1000,
         "logRequests" : false,
         "disabledMethods" : {
             "blockchain" : ["getBlockRangeInfo"],

--- a/libs/Database.js
+++ b/libs/Database.js
@@ -674,7 +674,7 @@ class Database {
               skip: off,
               sort,
               session: this.session,
-            }).toArray();
+            }).maxTimeMS(fromRPC ? config.rpcConfig.maxDBTimeMS : 60000).toArray();
 
             result = EJSON.serialize(result);
           } else {
@@ -683,7 +683,7 @@ class Database {
               skip: off,
               sort: ['_id', 'asc'],
               session: this.session,
-            }).toArray();
+            }).maxTimeMS(fromRPC ? config.rpcConfig.maxDBTimeMS : 60000).toArray();
             result = EJSON.serialize(result);
           }
         }
@@ -704,7 +704,7 @@ class Database {
    * @param {JSON} query query to perform on the table
    * @returns {Object} returns a record if it exists, null otherwise
    */
-  async findOne(payload) { // eslint-disable-line no-unused-vars
+  async findOne(payload, fromRPC = false) { // eslint-disable-line no-unused-vars
     try {
       const { contract, table, query } = payload;
       log.info('findOne payload ', payload);
@@ -739,7 +739,7 @@ class Database {
             }
           }
 
-          result = await tableData.findOne(EJSON.deserialize(query), { session: this.session });
+          result = await tableData.findOne(EJSON.deserialize(query), { session: this.session }).maxTimeMS(fromRPC ? config.rpcConfig.maxDBTimeMS : 60000);
           if (result) {
             result = EJSON.serialize(result);
           }

--- a/libs/Database.js
+++ b/libs/Database.js
@@ -739,9 +739,10 @@ class Database {
             }
           }
 
-          result = await tableData.findOne(EJSON.deserialize(query), { session: this.session }).maxTimeMS(fromRPC ? config.rpcConfig.maxDBTimeMS : 60000);
+          result = await tableData.find(EJSON.deserialize(query), { session: this.session }).maxTimeMS(fromRPC ? config.rpcConfig.maxDBTimeMS : 60000);
           if (result) {
             result = EJSON.serialize(result);
+            result = result[0];
           }
         }
       }

--- a/plugins/JsonRPCServer.js
+++ b/plugins/JsonRPCServer.js
@@ -232,7 +232,7 @@ function contractsRPC() {
             contract,
             table,
             query,
-          });
+          }, true);
 
           callback(null, result);
         } else {


### PR DESCRIPTION
Defaults to 1 second for calls from RPC. If queries take longer than this, they are automatically killed. 

Don't merge yet, using this to easily run the tests.