### PR TITLE
Witness Disable Log And Test

### DIFF
--- a/contracts/witnesses.js
+++ b/contracts/witnesses.js
@@ -546,6 +546,9 @@ const changeCurrentWitness = async () => {
         if (scheduledWitness.missedRoundsInARow >= maxRoundsMissedInARow) {
           scheduledWitness.missedRoundsInARow = 0;
           scheduledWitness.enabled = false;
+
+          // Emit that witness got disabled
+          api.emit('witnessDisabledForMissingTooManyRounds', { witness: scheduledWitness.account });
         }
 
         await api.db.update('witnesses', scheduledWitness);
@@ -604,6 +607,9 @@ const changeCurrentWitness = async () => {
         if (scheduledWitness.missedRoundsInARow >= maxRoundsMissedInARow) {
           scheduledWitness.missedRoundsInARow = 0;
           scheduledWitness.enabled = false;
+
+          // Emit that witness got disabled
+          api.emit('witnessDisabledForMissingTooManyRounds', { witness: scheduledWitness.account });
         }
 
         await api.db.update('witnesses', scheduledWitness);

--- a/contracts/witnesses.js
+++ b/contracts/witnesses.js
@@ -548,7 +548,7 @@ const changeCurrentWitness = async () => {
           scheduledWitness.enabled = false;
 
           // Emit that witness got disabled
-          api.emit('witnessDisabledForMissingTooManyRounds', { witness: scheduledWitness.account });
+          api.emit('witnessDisabledForMissingTooManyRoundsInARow', { witness: scheduledWitness.account });
         }
 
         await api.db.update('witnesses', scheduledWitness);
@@ -609,7 +609,7 @@ const changeCurrentWitness = async () => {
           scheduledWitness.enabled = false;
 
           // Emit that witness got disabled
-          api.emit('witnessDisabledForMissingTooManyRounds', { witness: scheduledWitness.account });
+          api.emit('witnessDisabledForMissingTooManyRoundsInARow', { witness: scheduledWitness.account });
         }
 
         await api.db.update('witnesses', scheduledWitness);

--- a/test/witnesses.js
+++ b/test/witnesses.js
@@ -1847,7 +1847,7 @@ describe('witnesses', function () {
       const changeBlock = await fixture.database.getBlockInfo(22); // Witness changed on round 22
       const vopLogs = JSON.parse(changeBlock.virtualTransactions[0].logs);
       assert.equal(JSON.stringify(vopLogs.events[0]), '{"contract":"witnesses","event":"witnessMissedRound","data":{"witness":"witness6"}}');
-      assert.equal(JSON.stringify(vopLogs.events[1]), '{"contract":"witnesses","event":"witnessDisabledForMissingTooManyRounds","data":{"witness":"witness6"}}'); // Check for witness disabled log event
+      assert.equal(JSON.stringify(vopLogs.events[1]), '{"contract":"witnesses","event":"witnessDisabledForMissingTooManyRoundsInARow","data":{"witness":"witness6"}}'); // Check for witness disabled log event
 
       // Ensure witness got disabled
       const witnessWhoShouldBeDisabled = await fixture.database.findOne({


### PR DESCRIPTION
Resolves https://github.com/hive-engine/hivesmartcontracts/issues/47. 

There existed no test for witnesses getting disabled automatically by missing witness params `missedRoundsInARow` value of blocks in a row. This adds a test for that, and it also adds a log event for that in the witness contract and verifies that the event gets emitted.