### PR TITLE
Fix witness register being set to false

### DIFF
--- a/witness_action.js
+++ b/witness_action.js
@@ -108,7 +108,7 @@ program
       RPCPort: extRPCNodePort,
       P2PPort: extP2PPort,
       signingKey: publicSigningKey,
-      enabled: false,
+      enabled: true,
     };
     if (ip && domain) {
       // eslint-disable-next-line no-console


### PR DESCRIPTION
Looks like I messed up somewhere with cleaning up a merge conflict and set enabled to false in registering, this fixes that.