### PR TITLE
[Consensus] Truncate json metadata to only fields we use

### DIFF
--- a/plugins/Streamer.js
+++ b/plugins/Streamer.js
@@ -67,6 +67,8 @@ const translateAsset = (asset) => {
   throw new Error("Unhandled asset: " + asset.nai);
 }
 
+const allowedJsonMetaFields = ['app', 'tags', 'ssc'];
+
 // parse the transactions found in a Hive block
 const parseTransactions = (refBlockNumber, block) => {
   const newTransactions = [];
@@ -124,6 +126,13 @@ const parseTransactions = (refBlockNumber, block) => {
           } else if (operationType === 'comment') {
             sender = operationValue.author;
             const commentMeta = operationValue.json_metadata !== '' ? JSON.parse(operationValue.json_metadata) : null;
+            if (refBlockNumber > 99999999 && commentMeta) {
+              Object.keys(commentMeta).forEach(k => {
+                if (allowedJsonMetaFields.indexOf(k) === -1) {
+                  delete commentMeta[k];
+                }
+              });
+            }
 
             if (commentMeta && commentMeta.ssc) {
               id = commentMeta.ssc.id; // eslint-disable-line prefer-destructuring


### PR DESCRIPTION
This is a consensus change that will remove the part of json metadat we do not use for comments contract.