### PR TITLE
Replace vm2 with isolated_vm

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04]
-        node-version: [18.x]
+        node-version: [18.x, 20.x]
         mongodb-version: ['4.4', '5.0', '6.0', '7.0']
 
     steps:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04]
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [18.x]
         mongodb-version: ['4.4', '5.0', '6.0', '7.0']
 
     steps:

--- a/libs/SmartContracts.js
+++ b/libs/SmartContracts.js
@@ -85,11 +85,11 @@ class SmartContracts {
             RegExp.prototype.constructor = function () { };
             RegExp.prototype.exec = function () {  };
             RegExp.prototype.test = function () {  };
-
+  
             let actions = {};
-
+  
             ###ACTIONS###
-
+  
             const execute = async function () {
               try {
                 if (api.action && typeof api.action === 'string' && typeof actions[api.action] === 'function') {
@@ -105,7 +105,7 @@ class SmartContracts {
                 done(error);
               }
             }
-
+  
             execute();
           }
 
@@ -114,8 +114,6 @@ class SmartContracts {
 
         // the code of the smart contarct comes as a Base64 encoded string
         codeTemplate = codeTemplate.replace('###ACTIONS###', Base64.decode(code));
-
-        // compile the code for faster executions later on
 
         const tables = {};
 
@@ -418,7 +416,6 @@ class SmartContracts {
           blockNumber,
           action,
           payload: JSON.parse(JSON.stringify(payloadObj)),
-          //db,
           BigNumber: new ivm.Reference((x) => BigNumber(x)),
           logs: new ivm.Reference(() => new ivm.ExternalCopy(JSON.parse(JSON.stringify(results.logs)))),
           random: new ivm.Reference(() => rng()),
@@ -548,7 +545,7 @@ class SmartContracts {
   }
 
   static getJSVM(jsVMTimeout) {
-    const isolate = new ivm.Isolate({ memoryLimit: 256 });
+    const isolate = new ivm.Isolate({ memoryLimit: 128 });
     const context = isolate.createContextSync();
     return {
       timeout: jsVMTimeout,

--- a/libs/SmartContracts.js
+++ b/libs/SmartContracts.js
@@ -567,12 +567,9 @@ class SmartContracts {
           resolve(error);
         });
         vm.context.global.setSync('sscglobal_externalCopy', x => new ivm.ExternalCopy(x));
-        Object.keys(vmState.api).forEach((key) => {
-            vm.context.global.setSync('sscglobal_' + key, key === 'payload' && typeof(vmState.api[key]) === 'object' ? new ivm.ExternalCopy(vmState.api[key]) : vmState.api[key]);
-            });
-        Object.keys(vmState.db).forEach((key) => {
-            vm.context.global.setSync('sscglobal_' + key, vmState.db[key]);
-            });
+        vm.context.global.setSync('sscglobal_api', new ivm.Reference(vmState.api));
+        vm.context.global.setSync('sscglobal_debug', vmState.api.debug);
+        vm.context.global.setSync('sscglobal_db', new ivm.Reference(vmState.db));
         vm.context.global.setSync('sscglobalv_isAlpha', new ivm.Callback(validator.isAlpha));
         vm.context.global.setSync('sscglobalv_isAlphanumeric', new ivm.Callback(validator.isAlphanumeric));
         vm.context.global.setSync('sscglobalv_blacklist', new ivm.Callback(validator.blacklist));
@@ -609,6 +606,38 @@ class SmartContracts {
         vm.context.global.setSync('sscglobal_bn_max', new ivm.Reference((...args) => BigNumber.max.apply(undefined, args.map(maybeDeref))));
 
         const wrappedCode = 'new ' + function() {
+          let _sscglobal_api = sscglobal_api;
+          let _sscglobal_debug = sscglobal_debug;
+          let _sscglobal_db = sscglobal_db;
+          let _sscglobal_externalCopy = sscglobal_externalCopy;
+          let _sscglobal_bn_construct = sscglobal_bn_construct;
+          let _sscglobal_bn_plus = sscglobal_bn_plus;
+          let _sscglobal_bn_minus = sscglobal_bn_minus;
+          let _sscglobal_bn_times = sscglobal_bn_times;
+          let _sscglobal_bn_multipliedBy = sscglobal_bn_multipliedBy;
+          let _sscglobal_bn_dividedBy = sscglobal_bn_dividedBy;
+          let _sscglobal_bn_sqrt = sscglobal_bn_sqrt;
+          let _sscglobal_bn_pow = sscglobal_bn_pow;
+          let _sscglobal_bn_negated = sscglobal_bn_negated;
+          let _sscglobal_bn_abs = sscglobal_bn_abs;
+          let _sscglobal_bn_lt = sscglobal_bn_lt;
+          let _sscglobal_bn_lte = sscglobal_bn_lte;
+          let _sscglobal_bn_eq = sscglobal_bn_eq;
+          let _sscglobal_bn_gt = sscglobal_bn_gt;
+          let _sscglobal_bn_gte = sscglobal_bn_gte;
+          let _sscglobal_bn_dp = sscglobal_bn_dp;
+          let _sscglobal_bn_decimalPlaces = sscglobal_bn_decimalPlaces;
+          let _sscglobal_bn_isNaN = sscglobal_bn_isNaN;
+          let _sscglobal_bn_isFinite = sscglobal_bn_isFinite;
+          let _sscglobal_bn_isInteger = sscglobal_bn_isInteger;
+          let _sscglobal_bn_isPositive = sscglobal_bn_isPositive;
+          let _sscglobal_bn_toFixed = sscglobal_bn_toFixed;
+          let _sscglobal_bn_toNumber = sscglobal_bn_toNumber;
+          let _sscglobal_bn_toString = sscglobal_bn_toString;
+          let _sscglobal_bn_integerValue = sscglobal_bn_integerValue;
+          let _sscglobal_bn_min = sscglobal_bn_min;
+          let _sscglobal_bn_max = sscglobal_bn_max;
+
           let deepUnwrap = (x) => {
             let y = x;
             if (typeof x === "object" && x !== null) {
@@ -622,81 +651,89 @@ class SmartContracts {
           };
           let applyWrapper = (fn) => {
             return async (...args) => {
-              const extArgs = args.map(x => sscglobal_externalCopy(deepUnwrap(x)).copyInto());
+              const extArgs = args.map(x => _sscglobal_externalCopy(deepUnwrap(x)).copyInto());
               const result = await fn.applySyncPromise(undefined, extArgs);
               return (typeof result === 'object' && result.copy) ? await result.copy() : result;
             }
           };
           let applyWrapperSync = (fn) => {
             return (...args) => {
-              const extArgs = args.map(x => sscglobal_externalCopy(deepUnwrap(x)).copyInto());
+              const extArgs = args.map(x => _sscglobal_externalCopy(deepUnwrap(x)).copyInto());
               const result = fn.applySync(undefined, extArgs);
               return (typeof result === 'object' && result.copy) ? result.copy() : result;
             }
           };
           let maybeUnwrap = (x) => {
-            return typeof x === 'object' && x !== null && x.unwrap ? x.unwrap() : x;
+            return typeof x === 'object' && x !== null && x._sscg_unwrap ? _sscglobal_bn_construct.applySync(undefined, [x.toString()]) : x;
           };
           let makeBigNumber = (x) => {
-            return bigNumberWrapper(sscglobal_bn_construct.applySync(undefined, [maybeUnwrap(x)]));
+            return bigNumberWrapper(_sscglobal_bn_construct.applySync(undefined, [maybeUnwrap(x)]));
           };
           let bigNumberWrapper = (x) => {
             return {
-              plus: (y) => bigNumberWrapper(sscglobal_bn_plus.applySync(undefined,[x, maybeUnwrap(y)])),
-              minus: (y) => bigNumberWrapper(sscglobal_bn_minus.applySync(undefined,[x, maybeUnwrap(y)])),
-              times: (y) => bigNumberWrapper(sscglobal_bn_times.applySync(undefined,[x, maybeUnwrap(y)])),
-              multipliedBy: (y, z) => bigNumberWrapper(sscglobal_bn_multipliedBy.applySync(undefined,[x, maybeUnwrap(y), z])),
-              dividedBy: (y, z) => bigNumberWrapper(sscglobal_bn_dividedBy.applySync(undefined,[x, maybeUnwrap(y), z])),
-              sqrt: () => bigNumberWrapper(sscglobal_bn_sqrt.applySync(undefined,[x])),
-              pow: (y) => bigNumberWrapper(sscglobal_bn_pow.applySync(undefined,[x, maybeUnwrap(y)])),
-              negated: () => bigNumberWrapper(sscglobal_bn_negated.applySync(undefined,[x])),
-              abs: () => bigNumberWrapper(sscglobal_bn_abs.applySync(undefined,[x])),
-              lt: (y) => sscglobal_bn_lt.applySync(undefined, [x, maybeUnwrap(y)]),
-              lte: (y) => sscglobal_bn_lte.applySync(undefined, [x, maybeUnwrap(y)]),
-              eq: (y) => sscglobal_bn_eq.applySync(undefined, [x, maybeUnwrap(y)]),
-              gt: (y) => sscglobal_bn_gt.applySync(undefined, [x, maybeUnwrap(y)]),
-              gte: (y) => sscglobal_bn_gte.applySync(undefined, [x, maybeUnwrap(y)]),
-              dp: (y, z) => { const ret = sscglobal_bn_dp.applySync(undefined, [x, y, z]);
+              plus: (y) => bigNumberWrapper(_sscglobal_bn_plus.applySync(undefined,[x, maybeUnwrap(y)])),
+              minus: (y) => bigNumberWrapper(_sscglobal_bn_minus.applySync(undefined,[x, maybeUnwrap(y)])),
+              times: (y) => bigNumberWrapper(_sscglobal_bn_times.applySync(undefined,[x, maybeUnwrap(y)])),
+              multipliedBy: (y, z) => bigNumberWrapper(_sscglobal_bn_multipliedBy.applySync(undefined,[x, maybeUnwrap(y), z])),
+              dividedBy: (y, z) => bigNumberWrapper(_sscglobal_bn_dividedBy.applySync(undefined,[x, maybeUnwrap(y), z])),
+              sqrt: () => bigNumberWrapper(_sscglobal_bn_sqrt.applySync(undefined,[x])),
+              pow: (y) => bigNumberWrapper(_sscglobal_bn_pow.applySync(undefined,[x, maybeUnwrap(y)])),
+              negated: () => bigNumberWrapper(_sscglobal_bn_negated.applySync(undefined,[x])),
+              abs: () => bigNumberWrapper(_sscglobal_bn_abs.applySync(undefined,[x])),
+              lt: (y) => _sscglobal_bn_lt.applySync(undefined, [x, maybeUnwrap(y)]),
+              lte: (y) => _sscglobal_bn_lte.applySync(undefined, [x, maybeUnwrap(y)]),
+              eq: (y) => _sscglobal_bn_eq.applySync(undefined, [x, maybeUnwrap(y)]),
+              gt: (y) => _sscglobal_bn_gt.applySync(undefined, [x, maybeUnwrap(y)]),
+              gte: (y) => _sscglobal_bn_gte.applySync(undefined, [x, maybeUnwrap(y)]),
+              dp: (y, z) => { const ret = _sscglobal_bn_dp.applySync(undefined, [x, y, z]);
                 return typeof y === 'number' ? bigNumberWrapper(ret) : ret;
               },
-              decimalPlaces: (y, z) => { const ret = sscglobal_bn_decimalPlaces.applySync(undefined, [x, y, z]);
+              decimalPlaces: (y, z) => { const ret = _sscglobal_bn_decimalPlaces.applySync(undefined, [x, y, z]);
                 return typeof y === 'number' ? bigNumberWrapper(ret) : ret;
               },
-              isNaN: () => sscglobal_bn_isNaN.applySync(undefined, [x]),
-              isFinite: () => sscglobal_bn_isFinite.applySync(undefined, [x]),
-              isInteger: () => sscglobal_bn_isInteger.applySync(undefined, [x]),
-              isPositive: () => sscglobal_bn_isPositive.applySync(undefined, [x]),
-              toFixed: (y, z) => sscglobal_bn_toFixed.applySync(undefined, [x, y, z]),
-              toNumber: () => sscglobal_bn_toNumber.applySync(undefined, [x]),
-              toString: () => sscglobal_bn_toString.applySync(undefined, [x]),
-              integerValue: (y) => bigNumberWrapper(sscglobal_bn_integerValue.applySync(undefined, [x, y])),
-              unwrap: () => x,
-              [Symbol.toPrimitive]: () => sscglobal_bn_toNumber.applySync(undefined, [x]),
+              isNaN: () => _sscglobal_bn_isNaN.applySync(undefined, [x]),
+              isFinite: () => _sscglobal_bn_isFinite.applySync(undefined, [x]),
+              isInteger: () => _sscglobal_bn_isInteger.applySync(undefined, [x]),
+              isPositive: () => _sscglobal_bn_isPositive.applySync(undefined, [x]),
+              toFixed: (y, z) => _sscglobal_bn_toFixed.applySync(undefined, [x, y, z]),
+              toNumber: () => _sscglobal_bn_toNumber.applySync(undefined, [x]),
+              toString: () => _sscglobal_bn_toString.applySync(undefined, [x]),
+              integerValue: (y) => bigNumberWrapper(_sscglobal_bn_integerValue.applySync(undefined, [x, y])),
+              _sscg_unwrap: true,//() => x,
+              [Symbol.toPrimitive]: () => _sscglobal_bn_toNumber.applySync(undefined, [x]),
             };
           };
+          let getApiProp = (k) => {
+            const v = _sscglobal_api.getSync(k, { copy: true });
+            return typeof v !== 'undefined' ? v : null;
+          };
+          let getDbProp = (k) => {
+            const v = _sscglobal_db.getSync(k, { copy: true });
+            return typeof v !== 'undefined' ? v : null;
+          };
           global.api = {
-            sender: typeof sscglobal_sender !== 'undefined' ? sscglobal_sender : null,
-            owner: typeof sscglobal_owner !== 'undefined' ? sscglobal_owner : null,
-            action: sscglobal_action,
-            payload: typeof sscglobal_payload === 'object' && sscglobal_payload.copy ? sscglobal_payload.copy() : sscglobal_payload,
-            transactionId: sscglobal_transactionId,
-            blockNumber: sscglobal_blockNumber,
-            refHiveBlockNumber: sscglobal_refHiveBlockNumber,
-            hiveBlockTimestamp: sscglobal_hiveBlockTimestamp,
-            contractVersion: sscglobal_contractVersion,
+            sender: getApiProp('sender'),
+            owner: getApiProp('owner'),
+            action: getApiProp('action'),
+            payload: getApiProp('payload'),
+            transactionId: getApiProp('transactionId'),
+            blockNumber: getApiProp('blockNumber'),
+            refHiveBlockNumber: getApiProp('refHiveBlockNumber'),
+            hiveBlockTimestamp: getApiProp('hiveBlockTimestamp'),
+            contractVersion: getApiProp('contractVersion'),
             db: {
-              createTable: typeof sscglobal_createTable !== 'undefined' ? applyWrapper(sscglobal_createTable) : null,
-              addIndexes: typeof sscglobal_addIndexes !== 'undefined' ? applyWrapper(sscglobal_addIndexes) : null,
-              find: applyWrapper(sscglobal_find),
-              findInTable: applyWrapper(sscglobal_findInTable),
-              findOne: applyWrapper(sscglobal_findOne),
-              findOneInTable: applyWrapper(sscglobal_findOneInTable),
-              findContract: applyWrapper(sscglobal_findContract),
-              insert: applyWrapper(sscglobal_insert),
-              remove: applyWrapper(sscglobal_remove),
-              update: applyWrapper(sscglobal_update),
-              tableExists: applyWrapper(sscglobal_tableExists),
-              getBlockInfo: typeof sscglobal_getBlockInfo !== 'undefined' ? applyWrapper(sscglobal_getBlockInfo) : null,
+              createTable: applyWrapper(getDbProp('createTable')),
+              addIndexes: applyWrapper(getDbProp('addIndexes')),
+              find: applyWrapper(getDbProp('find')),
+              findInTable: applyWrapper(getDbProp('findInTable')),
+              findOne: applyWrapper(getDbProp('findOne')),
+              findOneInTable: applyWrapper(getDbProp('findOneInTable')),
+              findContract: applyWrapper(getDbProp('findContract')),
+              insert: applyWrapper(getDbProp('insert')),
+              remove: applyWrapper(getDbProp('remove')),
+              update: applyWrapper(getDbProp('update')),
+              tableExists: applyWrapper(getDbProp('tableExists')),
+              getBlockInfo: applyWrapper(getDbProp('getBlockInfo')),
             },
             BigNumber: makeBigNumber,
             validator: {
@@ -707,19 +744,19 @@ class SmartContracts {
               isIP: sscglobalv_isIP,
               isFQDN: sscglobalv_isFQDN,
             },
-            logs: typeof sscglobal_logs !== 'undefined' ? applyWrapperSync(sscglobal_logs) : null,
-            SHA256: applyWrapperSync(sscglobal_SHA256),
-            checkSignature: applyWrapperSync(sscglobal_checkSignature),
-            random: applyWrapperSync(sscglobal_random),
-            debug: sscglobal_debug,
-            executeSmartContract: applyWrapper(sscglobal_executeSmartContract),
-            executeSmartContractAsOwner: typeof sscglobal_executeSmartContractAsOwner !== 'undefined' ? applyWrapper(sscglobal_executeSmartContractAsOwner) : null,
-            transferTokens: typeof sscglobal_transferTokens !== 'undefined' ? applyWrapper(sscglobal_transferTokens) : null,
-            transferTokensFromCallingContract: typeof sscglobal_transferTokensFromCallingContract !== 'undefined' ? applyWrapper(sscglobal_transferTokensFromCallingContract) : null,
-            verifyBlock: typeof sscglobal_verifyBlock !== 'undefined' ? applyWrapper(sscglobal_verifyBlock) : null,
-            emit: applyWrapper(sscglobal_emit),
-            assert: (condition, message) => sscglobal_assert.applySync(undefined, [!!condition, message]).copy(),
-            isValidAccountName: applyWrapperSync(sscglobal_isValidAccountName),
+            logs: applyWrapperSync(getApiProp('logs')),
+            SHA256: applyWrapperSync(getApiProp('SHA256')),
+            checkSignature: applyWrapperSync(getApiProp('checkSignature')),
+            random: applyWrapperSync(getApiProp('random')),
+            debug: _sscglobal_debug,
+            executeSmartContract: applyWrapper(getApiProp('executeSmartContract')),
+            executeSmartContractAsOwner: applyWrapper(getApiProp('executeSmartContractAsOwner')),
+            transferTokens: applyWrapper(getApiProp('transferTokens')),
+            transferTokensFromCallingContract: applyWrapper(getApiProp('transferTokensFromCallingContract')),
+            verifyBlock: applyWrapper(getApiProp('verifyBlock')),
+            emit: applyWrapper(getApiProp('emit')),
+            assert: (condition, message) => getApiProp('assert').applySync(undefined, [!!condition, message]).copy(),
+            isValidAccountName: applyWrapperSync(getApiProp('isValidAccountName')),
           };
           global.api.BigNumber.ROUND_UP = 0;
           global.api.BigNumber.ROUND_DOWN = 1;
@@ -730,21 +767,47 @@ class SmartContracts {
           global.api.BigNumber.ROUND_HALF_EVEN = 6;
           global.api.BigNumber.ROUND_HALF_CEIL = 7;
           global.api.BigNumber.ROUND_HALF_FLOOR = 8;
-          global.api.BigNumber.min = (...args) => bigNumberWrapper(sscglobal_bn_min.applySync(undefined, args.map(maybeUnwrap)));
-          global.api.BigNumber.max = (...args) => bigNumberWrapper(sscglobal_bn_max.applySync(undefined, args.map(maybeUnwrap)));
+          global.api.BigNumber.min = (...args) => bigNumberWrapper(_sscglobal_bn_min.applySync(undefined, args.map(maybeUnwrap)));
+          global.api.BigNumber.max = (...args) => bigNumberWrapper(_sscglobal_bn_max.applySync(undefined, args.map(maybeUnwrap)));
         };
+
         const compiledWrapper = vm.isolate.compileScriptSync(wrappedCode);
         const compiled = vm.isolate.compileScriptSync(contractCode);
-        //vm.isolate.startCpuProfiler("profssc");
         compiledWrapper.run(vm.context).then(() => {
-          /*vm.isolate.stopCpuProfiler("profssc").then((tcpArr) => {
-            tcpArr.forEach(x => {
-              if (x.profile.endTime - x.profile.startTime > 500000) { console.log(JSON.stringify(x)); }
-            });*/
+            vm.context.global.delete('sscglobal_api');
+            vm.context.global.delete('sscglobal_debug');
+            vm.context.global.delete('sscglobal_db');
+            vm.context.global.delete('sscglobal_externalCopy');
+            vm.context.global.delete('sscglobal_bn_construct');
+            vm.context.global.delete('sscglobal_bn_plus');
+            vm.context.global.delete('sscglobal_bn_minus');
+            vm.context.global.delete('sscglobal_bn_times');
+            vm.context.global.delete('sscglobal_bn_multipliedBy');
+            vm.context.global.delete('sscglobal_bn_dividedBy');
+            vm.context.global.delete('sscglobal_bn_sqrt');
+            vm.context.global.delete('sscglobal_bn_pow');
+            vm.context.global.delete('sscglobal_bn_negated');
+            vm.context.global.delete('sscglobal_bn_abs');
+            vm.context.global.delete('sscglobal_bn_lt');
+            vm.context.global.delete('sscglobal_bn_lte');
+            vm.context.global.delete('sscglobal_bn_eq');
+            vm.context.global.delete('sscglobal_bn_gt');
+            vm.context.global.delete('sscglobal_bn_gte');
+            vm.context.global.delete('sscglobal_bn_dp');
+            vm.context.global.delete('sscglobal_bn_decimalPlaces');
+            vm.context.global.delete('sscglobal_bn_isNaN');
+            vm.context.global.delete('sscglobal_bn_isFinite');
+            vm.context.global.delete('sscglobal_bn_isInteger');
+            vm.context.global.delete('sscglobal_bn_isPositive');
+            vm.context.global.delete('sscglobal_bn_toFixed');
+            vm.context.global.delete('sscglobal_bn_toNumber');
+            vm.context.global.delete('sscglobal_bn_toString');
+            vm.context.global.delete('sscglobal_bn_integerValue');
+            vm.context.global.delete('sscglobal_bn_min');
+            vm.context.global.delete('sscglobal_bn_max');
             compiled.run(vm.context).then(() => {
               vm.isolate.dispose();
             });
-          //});
         });
       } else {
         resolve('no JS VM available');

--- a/libs/SmartContracts.js
+++ b/libs/SmartContracts.js
@@ -15,6 +15,9 @@ const { CONSTANTS } = require('../libs/Constants');
 const RESERVED_CONTRACT_NAMES = ['contract', 'blockProduction', 'null'];
 const RESERVED_ACTIONS = ['createSSC'];
 
+const JSVMs = [];
+const MAXJSVMs = 5;
+
 const maybeDeref = (y) => typeof y === 'object' && y !== null && y.deref ? y.deref() : y;
 function deepDeref(x) {
   let y = x;
@@ -545,274 +548,284 @@ class SmartContracts {
   }
 
   static getJSVM(jsVMTimeout) {
-    const isolate = new ivm.Isolate({ memoryLimit: 128 });
-    const context = isolate.createContextSync();
-    return {
-      timeout: jsVMTimeout,
-      context,
-      isolate,
-      isActive: true,
-    };
+    let vm = null;
+
+    vm = JSVMs.find(v => v.inUse === false);
+    if (vm === undefined) {
+      if (JSVMs.length < MAXJSVMs) {
+        const isolate = new ivm.Isolate({ memoryLimit: 128 });
+        const context = isolate.createContextSync();
+        vm = {
+           timeout: jsVMTimeout,
+           context,
+           isolate,
+           inUse: true,
+        };
+        JSVMs.push(vm);
+        return vm;
+      }
+    } else {
+      vm.inUse = true;
+      return vm;
+    }
+    return null;
   }
 
   // run the contractCode in a VM with the vmState as a state for the VM
-  static runContractCode(vmState, contractCode, jsVMTimeout) {
-    return new Promise((resolve) => {
-      // run the code in the VM
-      const vm = SmartContracts.getJSVM(jsVMTimeout);
-      if (vm !== null) {
-        vm.context.global.setSync('global', vm.context.global.derefInto());
-        vm.context.global.setSync('done', (error) => {
-          vm.isActive = false;
-          resolve(error);
-        });
-        vm.context.global.setSync('sscglobal_externalCopy', x => new ivm.ExternalCopy(x));
-        vm.context.global.setSync('sscglobal_api', new ivm.Reference(vmState.api));
-        vm.context.global.setSync('sscglobal_debug', vmState.api.debug);
-        vm.context.global.setSync('sscglobal_db', new ivm.Reference(vmState.db));
-        vm.context.global.setSync('sscglobalv_isAlpha', new ivm.Callback(validator.isAlpha));
-        vm.context.global.setSync('sscglobalv_isAlphanumeric', new ivm.Callback(validator.isAlphanumeric));
-        vm.context.global.setSync('sscglobalv_blacklist', new ivm.Callback(validator.blacklist));
-        vm.context.global.setSync('sscglobalv_isUppercase', new ivm.Callback(validator.isUppercase));
-        vm.context.global.setSync('sscglobalv_isIP', new ivm.Callback(validator.isIP));
-        vm.context.global.setSync('sscglobalv_isFQDN', new ivm.Callback(validator.isFQDN));
+  static async runContractCode(vmState, contractCode, jsVMTimeout) {
+    // run the code in the VM
+    const vm = SmartContracts.getJSVM(jsVMTimeout);
+    let contractError = null
+    if (vm !== null) {
+      vm.context.global.setSync('global', vm.context.global.derefInto());
+      vm.context.global.setSync('done', (error) => {
+        contractError = error;
+      });
+      vm.context.global.setSync('sscglobal_externalCopy', x => new ivm.ExternalCopy(x));
+      vm.context.global.setSync('sscglobal_api', new ivm.Reference(vmState.api));
+      vm.context.global.setSync('sscglobal_debug', vmState.api.debug);
+      vm.context.global.setSync('sscglobal_db', new ivm.Reference(vmState.db));
+      vm.context.global.setSync('sscglobalv_isAlpha', new ivm.Callback(validator.isAlpha));
+      vm.context.global.setSync('sscglobalv_isAlphanumeric', new ivm.Callback(validator.isAlphanumeric));
+      vm.context.global.setSync('sscglobalv_blacklist', new ivm.Callback(validator.blacklist));
+      vm.context.global.setSync('sscglobalv_isUppercase', new ivm.Callback(validator.isUppercase));
+      vm.context.global.setSync('sscglobalv_isIP', new ivm.Callback(validator.isIP));
+      vm.context.global.setSync('sscglobalv_isFQDN', new ivm.Callback(validator.isFQDN));
 
-        vm.context.global.setSync('sscglobal_bn_construct', new ivm.Reference((x, y) => BigNumber(maybeDeref(x))));
-        vm.context.global.setSync('sscglobal_bn_plus', new ivm.Reference((x, y) => x.deref().plus(maybeDeref(y))));
-        vm.context.global.setSync('sscglobal_bn_minus', new ivm.Reference((x, y) => x.deref().minus(maybeDeref(y))));
-        vm.context.global.setSync('sscglobal_bn_times', new ivm.Reference((x, y) => x.deref().times(maybeDeref(y))));
-        vm.context.global.setSync('sscglobal_bn_multipliedBy', new ivm.Reference((x, y, z) => x.deref().multipliedBy(maybeDeref(y), z)));
-        vm.context.global.setSync('sscglobal_bn_dividedBy', new ivm.Reference((x, y, z) => x.deref().dividedBy(maybeDeref(y), z)));
-        vm.context.global.setSync('sscglobal_bn_sqrt', new ivm.Reference((x) => x.deref().sqrt()));
-        vm.context.global.setSync('sscglobal_bn_pow', new ivm.Reference((x, y) => x.deref().pow(maybeDeref(y))));
-        vm.context.global.setSync('sscglobal_bn_negated', new ivm.Reference((x) => x.deref().negated()));
-        vm.context.global.setSync('sscglobal_bn_abs', new ivm.Reference((x) => x.deref().abs()));
-        vm.context.global.setSync('sscglobal_bn_lt', new ivm.Reference((x, y) => x.deref().lt(maybeDeref(y))));
-        vm.context.global.setSync('sscglobal_bn_lte', new ivm.Reference((x, y) => x.deref().lte(maybeDeref(y))));
-        vm.context.global.setSync('sscglobal_bn_eq', new ivm.Reference((x, y) => x.deref().eq(maybeDeref(y))));
-        vm.context.global.setSync('sscglobal_bn_gt', new ivm.Reference((x, y) => x.deref().gt(maybeDeref(y))));
-        vm.context.global.setSync('sscglobal_bn_gte', new ivm.Reference((x, y) => x.deref().gte(maybeDeref(y))));
-        vm.context.global.setSync('sscglobal_bn_dp', new ivm.Reference((x, y, z) => x.deref().dp(y, z)));
-        vm.context.global.setSync('sscglobal_bn_decimalPlaces', new ivm.Reference((x, y, z) => x.deref().decimalPlaces(y, z)));
-        vm.context.global.setSync('sscglobal_bn_isNaN', new ivm.Reference((x) => x.deref().isNaN()));
-        vm.context.global.setSync('sscglobal_bn_isFinite', new ivm.Reference((x) => x.deref().isFinite()));
-        vm.context.global.setSync('sscglobal_bn_isInteger', new ivm.Reference((x) => x.deref().isInteger()));
-        vm.context.global.setSync('sscglobal_bn_isPositive', new ivm.Reference((x) => x.deref().isPositive()));
-        vm.context.global.setSync('sscglobal_bn_toFixed', new ivm.Reference((x, y, z) => x.deref().toFixed(y, z)));
-        vm.context.global.setSync('sscglobal_bn_toNumber', new ivm.Reference((x) => x.deref().toNumber()));
-        vm.context.global.setSync('sscglobal_bn_toString', new ivm.Reference((x) => x.deref().toString()));
-        vm.context.global.setSync('sscglobal_bn_integerValue', new ivm.Reference((x, y) => x.deref().integerValue(y)));
-        vm.context.global.setSync('sscglobal_bn_min', new ivm.Reference((...args) => BigNumber.min.apply(undefined, args.map(maybeDeref))));
-        vm.context.global.setSync('sscglobal_bn_max', new ivm.Reference((...args) => BigNumber.max.apply(undefined, args.map(maybeDeref))));
+      vm.context.global.setSync('sscglobal_bn_construct', new ivm.Reference((x, y) => BigNumber(maybeDeref(x))));
+      vm.context.global.setSync('sscglobal_bn_plus', new ivm.Reference((x, y) => x.deref().plus(maybeDeref(y))));
+      vm.context.global.setSync('sscglobal_bn_minus', new ivm.Reference((x, y) => x.deref().minus(maybeDeref(y))));
+      vm.context.global.setSync('sscglobal_bn_times', new ivm.Reference((x, y) => x.deref().times(maybeDeref(y))));
+      vm.context.global.setSync('sscglobal_bn_multipliedBy', new ivm.Reference((x, y, z) => x.deref().multipliedBy(maybeDeref(y), z)));
+      vm.context.global.setSync('sscglobal_bn_dividedBy', new ivm.Reference((x, y, z) => x.deref().dividedBy(maybeDeref(y), z)));
+      vm.context.global.setSync('sscglobal_bn_sqrt', new ivm.Reference((x) => x.deref().sqrt()));
+      vm.context.global.setSync('sscglobal_bn_pow', new ivm.Reference((x, y) => x.deref().pow(maybeDeref(y))));
+      vm.context.global.setSync('sscglobal_bn_negated', new ivm.Reference((x) => x.deref().negated()));
+      vm.context.global.setSync('sscglobal_bn_abs', new ivm.Reference((x) => x.deref().abs()));
+      vm.context.global.setSync('sscglobal_bn_lt', new ivm.Reference((x, y) => x.deref().lt(maybeDeref(y))));
+      vm.context.global.setSync('sscglobal_bn_lte', new ivm.Reference((x, y) => x.deref().lte(maybeDeref(y))));
+      vm.context.global.setSync('sscglobal_bn_eq', new ivm.Reference((x, y) => x.deref().eq(maybeDeref(y))));
+      vm.context.global.setSync('sscglobal_bn_gt', new ivm.Reference((x, y) => x.deref().gt(maybeDeref(y))));
+      vm.context.global.setSync('sscglobal_bn_gte', new ivm.Reference((x, y) => x.deref().gte(maybeDeref(y))));
+      vm.context.global.setSync('sscglobal_bn_dp', new ivm.Reference((x, y, z) => x.deref().dp(y, z)));
+      vm.context.global.setSync('sscglobal_bn_decimalPlaces', new ivm.Reference((x, y, z) => x.deref().decimalPlaces(y, z)));
+      vm.context.global.setSync('sscglobal_bn_isNaN', new ivm.Reference((x) => x.deref().isNaN()));
+      vm.context.global.setSync('sscglobal_bn_isFinite', new ivm.Reference((x) => x.deref().isFinite()));
+      vm.context.global.setSync('sscglobal_bn_isInteger', new ivm.Reference((x) => x.deref().isInteger()));
+      vm.context.global.setSync('sscglobal_bn_isPositive', new ivm.Reference((x) => x.deref().isPositive()));
+      vm.context.global.setSync('sscglobal_bn_toFixed', new ivm.Reference((x, y, z) => x.deref().toFixed(y, z)));
+      vm.context.global.setSync('sscglobal_bn_toNumber', new ivm.Reference((x) => x.deref().toNumber()));
+      vm.context.global.setSync('sscglobal_bn_toString', new ivm.Reference((x) => x.deref().toString()));
+      vm.context.global.setSync('sscglobal_bn_integerValue', new ivm.Reference((x, y) => x.deref().integerValue(y)));
+      vm.context.global.setSync('sscglobal_bn_min', new ivm.Reference((...args) => BigNumber.min.apply(undefined, args.map(maybeDeref))));
+      vm.context.global.setSync('sscglobal_bn_max', new ivm.Reference((...args) => BigNumber.max.apply(undefined, args.map(maybeDeref))));
 
-        const wrappedCode = 'new ' + function() {
-          let _sscglobal_api = sscglobal_api;
-          let _sscglobal_debug = sscglobal_debug;
-          let _sscglobal_db = sscglobal_db;
-          let _sscglobal_externalCopy = sscglobal_externalCopy;
-          let _sscglobal_bn_construct = sscglobal_bn_construct;
-          let _sscglobal_bn_plus = sscglobal_bn_plus;
-          let _sscglobal_bn_minus = sscglobal_bn_minus;
-          let _sscglobal_bn_times = sscglobal_bn_times;
-          let _sscglobal_bn_multipliedBy = sscglobal_bn_multipliedBy;
-          let _sscglobal_bn_dividedBy = sscglobal_bn_dividedBy;
-          let _sscglobal_bn_sqrt = sscglobal_bn_sqrt;
-          let _sscglobal_bn_pow = sscglobal_bn_pow;
-          let _sscglobal_bn_negated = sscglobal_bn_negated;
-          let _sscglobal_bn_abs = sscglobal_bn_abs;
-          let _sscglobal_bn_lt = sscglobal_bn_lt;
-          let _sscglobal_bn_lte = sscglobal_bn_lte;
-          let _sscglobal_bn_eq = sscglobal_bn_eq;
-          let _sscglobal_bn_gt = sscglobal_bn_gt;
-          let _sscglobal_bn_gte = sscglobal_bn_gte;
-          let _sscglobal_bn_dp = sscglobal_bn_dp;
-          let _sscglobal_bn_decimalPlaces = sscglobal_bn_decimalPlaces;
-          let _sscglobal_bn_isNaN = sscglobal_bn_isNaN;
-          let _sscglobal_bn_isFinite = sscglobal_bn_isFinite;
-          let _sscglobal_bn_isInteger = sscglobal_bn_isInteger;
-          let _sscglobal_bn_isPositive = sscglobal_bn_isPositive;
-          let _sscglobal_bn_toFixed = sscglobal_bn_toFixed;
-          let _sscglobal_bn_toNumber = sscglobal_bn_toNumber;
-          let _sscglobal_bn_toString = sscglobal_bn_toString;
-          let _sscglobal_bn_integerValue = sscglobal_bn_integerValue;
-          let _sscglobal_bn_min = sscglobal_bn_min;
-          let _sscglobal_bn_max = sscglobal_bn_max;
+      const wrappedCode = 'new ' + function() {
+        let _sscglobal_api = sscglobal_api;
+        let _sscglobal_debug = sscglobal_debug;
+        let _sscglobal_db = sscglobal_db;
+        let _sscglobal_externalCopy = sscglobal_externalCopy;
+        let _sscglobal_bn_construct = sscglobal_bn_construct;
+        let _sscglobal_bn_plus = sscglobal_bn_plus;
+        let _sscglobal_bn_minus = sscglobal_bn_minus;
+        let _sscglobal_bn_times = sscglobal_bn_times;
+        let _sscglobal_bn_multipliedBy = sscglobal_bn_multipliedBy;
+        let _sscglobal_bn_dividedBy = sscglobal_bn_dividedBy;
+        let _sscglobal_bn_sqrt = sscglobal_bn_sqrt;
+        let _sscglobal_bn_pow = sscglobal_bn_pow;
+        let _sscglobal_bn_negated = sscglobal_bn_negated;
+        let _sscglobal_bn_abs = sscglobal_bn_abs;
+        let _sscglobal_bn_lt = sscglobal_bn_lt;
+        let _sscglobal_bn_lte = sscglobal_bn_lte;
+        let _sscglobal_bn_eq = sscglobal_bn_eq;
+        let _sscglobal_bn_gt = sscglobal_bn_gt;
+        let _sscglobal_bn_gte = sscglobal_bn_gte;
+        let _sscglobal_bn_dp = sscglobal_bn_dp;
+        let _sscglobal_bn_decimalPlaces = sscglobal_bn_decimalPlaces;
+        let _sscglobal_bn_isNaN = sscglobal_bn_isNaN;
+        let _sscglobal_bn_isFinite = sscglobal_bn_isFinite;
+        let _sscglobal_bn_isInteger = sscglobal_bn_isInteger;
+        let _sscglobal_bn_isPositive = sscglobal_bn_isPositive;
+        let _sscglobal_bn_toFixed = sscglobal_bn_toFixed;
+        let _sscglobal_bn_toNumber = sscglobal_bn_toNumber;
+        let _sscglobal_bn_toString = sscglobal_bn_toString;
+        let _sscglobal_bn_integerValue = sscglobal_bn_integerValue;
+        let _sscglobal_bn_min = sscglobal_bn_min;
+        let _sscglobal_bn_max = sscglobal_bn_max;
 
-          let deepUnwrap = (x) => {
-            let y = x;
-            if (typeof x === "object" && x !== null) {
-              Object.keys(x).forEach(k => {
-                  y[k] = deepUnwrap(y[k]);
-              });
-            } else if (typeof x === "array") {
-              y = x.map(deepUnwrap);
-            }
-            return maybeUnwrap(y);
-          };
-          let applyWrapper = (fn) => {
-            return async (...args) => {
-              const extArgs = args.map(x => _sscglobal_externalCopy(deepUnwrap(x)).copyInto());
-              const result = await fn.applySyncPromise(undefined, extArgs);
-              return (typeof result === 'object' && result.copy) ? await result.copy() : result;
-            }
-          };
-          let applyWrapperSync = (fn) => {
-            return (...args) => {
-              const extArgs = args.map(x => _sscglobal_externalCopy(deepUnwrap(x)).copyInto());
-              const result = fn.applySync(undefined, extArgs);
-              return (typeof result === 'object' && result.copy) ? result.copy() : result;
-            }
-          };
-          let maybeUnwrap = (x) => {
-            return typeof x === 'object' && x !== null && x._sscg_unwrap ? _sscglobal_bn_construct.applySync(undefined, [x.toString()]) : x;
-          };
-          let makeBigNumber = (x) => {
-            return bigNumberWrapper(_sscglobal_bn_construct.applySync(undefined, [maybeUnwrap(x)]));
-          };
-          let bigNumberWrapper = (x) => {
-            return {
-              plus: (y) => bigNumberWrapper(_sscglobal_bn_plus.applySync(undefined,[x, maybeUnwrap(y)])),
-              minus: (y) => bigNumberWrapper(_sscglobal_bn_minus.applySync(undefined,[x, maybeUnwrap(y)])),
-              times: (y) => bigNumberWrapper(_sscglobal_bn_times.applySync(undefined,[x, maybeUnwrap(y)])),
-              multipliedBy: (y, z) => bigNumberWrapper(_sscglobal_bn_multipliedBy.applySync(undefined,[x, maybeUnwrap(y), z])),
-              dividedBy: (y, z) => bigNumberWrapper(_sscglobal_bn_dividedBy.applySync(undefined,[x, maybeUnwrap(y), z])),
-              sqrt: () => bigNumberWrapper(_sscglobal_bn_sqrt.applySync(undefined,[x])),
-              pow: (y) => bigNumberWrapper(_sscglobal_bn_pow.applySync(undefined,[x, maybeUnwrap(y)])),
-              negated: () => bigNumberWrapper(_sscglobal_bn_negated.applySync(undefined,[x])),
-              abs: () => bigNumberWrapper(_sscglobal_bn_abs.applySync(undefined,[x])),
-              lt: (y) => _sscglobal_bn_lt.applySync(undefined, [x, maybeUnwrap(y)]),
-              lte: (y) => _sscglobal_bn_lte.applySync(undefined, [x, maybeUnwrap(y)]),
-              eq: (y) => _sscglobal_bn_eq.applySync(undefined, [x, maybeUnwrap(y)]),
-              gt: (y) => _sscglobal_bn_gt.applySync(undefined, [x, maybeUnwrap(y)]),
-              gte: (y) => _sscglobal_bn_gte.applySync(undefined, [x, maybeUnwrap(y)]),
-              dp: (y, z) => { const ret = _sscglobal_bn_dp.applySync(undefined, [x, y, z]);
-                return typeof y === 'number' ? bigNumberWrapper(ret) : ret;
-              },
-              decimalPlaces: (y, z) => { const ret = _sscglobal_bn_decimalPlaces.applySync(undefined, [x, y, z]);
-                return typeof y === 'number' ? bigNumberWrapper(ret) : ret;
-              },
-              isNaN: () => _sscglobal_bn_isNaN.applySync(undefined, [x]),
-              isFinite: () => _sscglobal_bn_isFinite.applySync(undefined, [x]),
-              isInteger: () => _sscglobal_bn_isInteger.applySync(undefined, [x]),
-              isPositive: () => _sscglobal_bn_isPositive.applySync(undefined, [x]),
-              toFixed: (y, z) => _sscglobal_bn_toFixed.applySync(undefined, [x, y, z]),
-              toNumber: () => _sscglobal_bn_toNumber.applySync(undefined, [x]),
-              toString: () => _sscglobal_bn_toString.applySync(undefined, [x]),
-              integerValue: (y) => bigNumberWrapper(_sscglobal_bn_integerValue.applySync(undefined, [x, y])),
-              _sscg_unwrap: true,//() => x,
-              [Symbol.toPrimitive]: () => _sscglobal_bn_toNumber.applySync(undefined, [x]),
-            };
-          };
-          let getApiProp = (k) => {
-            const v = _sscglobal_api.getSync(k, { copy: true });
-            return typeof v !== 'undefined' ? v : null;
-          };
-          let getDbProp = (k) => {
-            const v = _sscglobal_db.getSync(k, { copy: true });
-            return typeof v !== 'undefined' ? v : null;
-          };
-          global.api = {
-            sender: getApiProp('sender'),
-            owner: getApiProp('owner'),
-            action: getApiProp('action'),
-            payload: getApiProp('payload'),
-            transactionId: getApiProp('transactionId'),
-            blockNumber: getApiProp('blockNumber'),
-            refHiveBlockNumber: getApiProp('refHiveBlockNumber'),
-            hiveBlockTimestamp: getApiProp('hiveBlockTimestamp'),
-            contractVersion: getApiProp('contractVersion'),
-            db: {
-              createTable: applyWrapper(getDbProp('createTable')),
-              addIndexes: applyWrapper(getDbProp('addIndexes')),
-              find: applyWrapper(getDbProp('find')),
-              findInTable: applyWrapper(getDbProp('findInTable')),
-              findOne: applyWrapper(getDbProp('findOne')),
-              findOneInTable: applyWrapper(getDbProp('findOneInTable')),
-              findContract: applyWrapper(getDbProp('findContract')),
-              insert: applyWrapper(getDbProp('insert')),
-              remove: applyWrapper(getDbProp('remove')),
-              update: applyWrapper(getDbProp('update')),
-              tableExists: applyWrapper(getDbProp('tableExists')),
-              getBlockInfo: applyWrapper(getDbProp('getBlockInfo')),
-            },
-            BigNumber: makeBigNumber,
-            validator: {
-              isAlpha: sscglobalv_isAlpha,
-              isAlphanumeric: sscglobalv_isAlphanumeric,
-              blacklist: sscglobalv_blacklist,
-              isUppercase: sscglobalv_isUppercase,
-              isIP: sscglobalv_isIP,
-              isFQDN: sscglobalv_isFQDN,
-            },
-            logs: applyWrapperSync(getApiProp('logs')),
-            SHA256: applyWrapperSync(getApiProp('SHA256')),
-            checkSignature: applyWrapperSync(getApiProp('checkSignature')),
-            random: applyWrapperSync(getApiProp('random')),
-            debug: _sscglobal_debug,
-            executeSmartContract: applyWrapper(getApiProp('executeSmartContract')),
-            executeSmartContractAsOwner: applyWrapper(getApiProp('executeSmartContractAsOwner')),
-            transferTokens: applyWrapper(getApiProp('transferTokens')),
-            transferTokensFromCallingContract: applyWrapper(getApiProp('transferTokensFromCallingContract')),
-            verifyBlock: applyWrapper(getApiProp('verifyBlock')),
-            emit: applyWrapper(getApiProp('emit')),
-            assert: (condition, message) => getApiProp('assert').applySync(undefined, [!!condition, message]).copy(),
-            isValidAccountName: applyWrapperSync(getApiProp('isValidAccountName')),
-          };
-          global.api.BigNumber.ROUND_UP = 0;
-          global.api.BigNumber.ROUND_DOWN = 1;
-          global.api.BigNumber.ROUND_CEIL = 2;
-          global.api.BigNumber.ROUND_FLOOR = 3;
-          global.api.BigNumber.ROUND_HALF_UP = 4;
-          global.api.BigNumber.ROUND_HALF_DOWN = 5;
-          global.api.BigNumber.ROUND_HALF_EVEN = 6;
-          global.api.BigNumber.ROUND_HALF_CEIL = 7;
-          global.api.BigNumber.ROUND_HALF_FLOOR = 8;
-          global.api.BigNumber.min = (...args) => bigNumberWrapper(_sscglobal_bn_min.applySync(undefined, args.map(maybeUnwrap)));
-          global.api.BigNumber.max = (...args) => bigNumberWrapper(_sscglobal_bn_max.applySync(undefined, args.map(maybeUnwrap)));
-        };
-
-        const compiledWrapper = vm.isolate.compileScriptSync(wrappedCode);
-        const compiled = vm.isolate.compileScriptSync(contractCode);
-        compiledWrapper.run(vm.context).then(() => {
-            vm.context.global.delete('sscglobal_api');
-            vm.context.global.delete('sscglobal_debug');
-            vm.context.global.delete('sscglobal_db');
-            vm.context.global.delete('sscglobal_externalCopy');
-            vm.context.global.delete('sscglobal_bn_construct');
-            vm.context.global.delete('sscglobal_bn_plus');
-            vm.context.global.delete('sscglobal_bn_minus');
-            vm.context.global.delete('sscglobal_bn_times');
-            vm.context.global.delete('sscglobal_bn_multipliedBy');
-            vm.context.global.delete('sscglobal_bn_dividedBy');
-            vm.context.global.delete('sscglobal_bn_sqrt');
-            vm.context.global.delete('sscglobal_bn_pow');
-            vm.context.global.delete('sscglobal_bn_negated');
-            vm.context.global.delete('sscglobal_bn_abs');
-            vm.context.global.delete('sscglobal_bn_lt');
-            vm.context.global.delete('sscglobal_bn_lte');
-            vm.context.global.delete('sscglobal_bn_eq');
-            vm.context.global.delete('sscglobal_bn_gt');
-            vm.context.global.delete('sscglobal_bn_gte');
-            vm.context.global.delete('sscglobal_bn_dp');
-            vm.context.global.delete('sscglobal_bn_decimalPlaces');
-            vm.context.global.delete('sscglobal_bn_isNaN');
-            vm.context.global.delete('sscglobal_bn_isFinite');
-            vm.context.global.delete('sscglobal_bn_isInteger');
-            vm.context.global.delete('sscglobal_bn_isPositive');
-            vm.context.global.delete('sscglobal_bn_toFixed');
-            vm.context.global.delete('sscglobal_bn_toNumber');
-            vm.context.global.delete('sscglobal_bn_toString');
-            vm.context.global.delete('sscglobal_bn_integerValue');
-            vm.context.global.delete('sscglobal_bn_min');
-            vm.context.global.delete('sscglobal_bn_max');
-            compiled.run(vm.context).then(() => {
-              vm.isolate.dispose();
+        let deepUnwrap = (x) => {
+          let y = x;
+          if (typeof x === "object" && x !== null) {
+            Object.keys(x).forEach(k => {
+                y[k] = deepUnwrap(y[k]);
             });
-        });
-      } else {
-        resolve('no JS VM available');
-      }
-    });
+          } else if (typeof x === "array") {
+            y = x.map(deepUnwrap);
+          }
+          return maybeUnwrap(y);
+        };
+        let applyWrapper = (fn) => {
+          return async (...args) => {
+            const extArgs = args.map(x => _sscglobal_externalCopy(deepUnwrap(x)).copyInto());
+            const result = await fn.applySyncPromise(undefined, extArgs);
+            return (typeof result === 'object' && result.copy) ? await result.copy() : result;
+          }
+        };
+        let applyWrapperSync = (fn) => {
+          return (...args) => {
+            const extArgs = args.map(x => _sscglobal_externalCopy(deepUnwrap(x)).copyInto());
+            const result = fn.applySync(undefined, extArgs);
+            return (typeof result === 'object' && result.copy) ? result.copy() : result;
+          }
+        };
+        let maybeUnwrap = (x) => {
+          return typeof x === 'object' && x !== null && x._sscg_unwrap ? _sscglobal_bn_construct.applySync(undefined, [x.toString()]) : x;
+        };
+        let makeBigNumber = (x) => {
+          return bigNumberWrapper(_sscglobal_bn_construct.applySync(undefined, [maybeUnwrap(x)]));
+        };
+        let bigNumberWrapper = (x) => {
+          return {
+            plus: (y) => bigNumberWrapper(_sscglobal_bn_plus.applySync(undefined,[x, maybeUnwrap(y)])),
+            minus: (y) => bigNumberWrapper(_sscglobal_bn_minus.applySync(undefined,[x, maybeUnwrap(y)])),
+            times: (y) => bigNumberWrapper(_sscglobal_bn_times.applySync(undefined,[x, maybeUnwrap(y)])),
+            multipliedBy: (y, z) => bigNumberWrapper(_sscglobal_bn_multipliedBy.applySync(undefined,[x, maybeUnwrap(y), z])),
+            dividedBy: (y, z) => bigNumberWrapper(_sscglobal_bn_dividedBy.applySync(undefined,[x, maybeUnwrap(y), z])),
+            sqrt: () => bigNumberWrapper(_sscglobal_bn_sqrt.applySync(undefined,[x])),
+            pow: (y) => bigNumberWrapper(_sscglobal_bn_pow.applySync(undefined,[x, maybeUnwrap(y)])),
+            negated: () => bigNumberWrapper(_sscglobal_bn_negated.applySync(undefined,[x])),
+            abs: () => bigNumberWrapper(_sscglobal_bn_abs.applySync(undefined,[x])),
+            lt: (y) => _sscglobal_bn_lt.applySync(undefined, [x, maybeUnwrap(y)]),
+            lte: (y) => _sscglobal_bn_lte.applySync(undefined, [x, maybeUnwrap(y)]),
+            eq: (y) => _sscglobal_bn_eq.applySync(undefined, [x, maybeUnwrap(y)]),
+            gt: (y) => _sscglobal_bn_gt.applySync(undefined, [x, maybeUnwrap(y)]),
+            gte: (y) => _sscglobal_bn_gte.applySync(undefined, [x, maybeUnwrap(y)]),
+            dp: (y, z) => { const ret = _sscglobal_bn_dp.applySync(undefined, [x, y, z]);
+              return typeof y === 'number' ? bigNumberWrapper(ret) : ret;
+            },
+            decimalPlaces: (y, z) => { const ret = _sscglobal_bn_decimalPlaces.applySync(undefined, [x, y, z]);
+              return typeof y === 'number' ? bigNumberWrapper(ret) : ret;
+            },
+            isNaN: () => _sscglobal_bn_isNaN.applySync(undefined, [x]),
+            isFinite: () => _sscglobal_bn_isFinite.applySync(undefined, [x]),
+            isInteger: () => _sscglobal_bn_isInteger.applySync(undefined, [x]),
+            isPositive: () => _sscglobal_bn_isPositive.applySync(undefined, [x]),
+            toFixed: (y, z) => _sscglobal_bn_toFixed.applySync(undefined, [x, y, z]),
+            toNumber: () => _sscglobal_bn_toNumber.applySync(undefined, [x]),
+            toString: () => _sscglobal_bn_toString.applySync(undefined, [x]),
+            integerValue: (y) => bigNumberWrapper(_sscglobal_bn_integerValue.applySync(undefined, [x, y])),
+            _sscg_unwrap: true,//() => x,
+            [Symbol.toPrimitive]: () => _sscglobal_bn_toNumber.applySync(undefined, [x]),
+          };
+        };
+        let getApiProp = (k) => {
+          const v = _sscglobal_api.getSync(k, { copy: true });
+          return typeof v !== 'undefined' ? v : null;
+        };
+        let getDbProp = (k) => {
+          const v = _sscglobal_db.getSync(k, { copy: true });
+          return typeof v !== 'undefined' ? v : null;
+        };
+        global.api = {
+          sender: getApiProp('sender'),
+          owner: getApiProp('owner'),
+          action: getApiProp('action'),
+          payload: getApiProp('payload'),
+          transactionId: getApiProp('transactionId'),
+          blockNumber: getApiProp('blockNumber'),
+          refHiveBlockNumber: getApiProp('refHiveBlockNumber'),
+          hiveBlockTimestamp: getApiProp('hiveBlockTimestamp'),
+          contractVersion: getApiProp('contractVersion'),
+          db: {
+            createTable: applyWrapper(getDbProp('createTable')),
+            addIndexes: applyWrapper(getDbProp('addIndexes')),
+            find: applyWrapper(getDbProp('find')),
+            findInTable: applyWrapper(getDbProp('findInTable')),
+            findOne: applyWrapper(getDbProp('findOne')),
+            findOneInTable: applyWrapper(getDbProp('findOneInTable')),
+            findContract: applyWrapper(getDbProp('findContract')),
+            insert: applyWrapper(getDbProp('insert')),
+            remove: applyWrapper(getDbProp('remove')),
+            update: applyWrapper(getDbProp('update')),
+            tableExists: applyWrapper(getDbProp('tableExists')),
+            getBlockInfo: applyWrapper(getDbProp('getBlockInfo')),
+          },
+          BigNumber: makeBigNumber,
+          validator: {
+            isAlpha: sscglobalv_isAlpha,
+            isAlphanumeric: sscglobalv_isAlphanumeric,
+            blacklist: sscglobalv_blacklist,
+            isUppercase: sscglobalv_isUppercase,
+            isIP: sscglobalv_isIP,
+            isFQDN: sscglobalv_isFQDN,
+          },
+          logs: applyWrapperSync(getApiProp('logs')),
+          SHA256: applyWrapperSync(getApiProp('SHA256')),
+          checkSignature: applyWrapperSync(getApiProp('checkSignature')),
+          random: applyWrapperSync(getApiProp('random')),
+          debug: _sscglobal_debug,
+          executeSmartContract: applyWrapper(getApiProp('executeSmartContract')),
+          executeSmartContractAsOwner: applyWrapper(getApiProp('executeSmartContractAsOwner')),
+          transferTokens: applyWrapper(getApiProp('transferTokens')),
+          transferTokensFromCallingContract: applyWrapper(getApiProp('transferTokensFromCallingContract')),
+          verifyBlock: applyWrapper(getApiProp('verifyBlock')),
+          emit: applyWrapper(getApiProp('emit')),
+          assert: (condition, message) => getApiProp('assert').applySync(undefined, [!!condition, message]).copy(),
+          isValidAccountName: applyWrapperSync(getApiProp('isValidAccountName')),
+        };
+        global.api.BigNumber.ROUND_UP = 0;
+        global.api.BigNumber.ROUND_DOWN = 1;
+        global.api.BigNumber.ROUND_CEIL = 2;
+        global.api.BigNumber.ROUND_FLOOR = 3;
+        global.api.BigNumber.ROUND_HALF_UP = 4;
+        global.api.BigNumber.ROUND_HALF_DOWN = 5;
+        global.api.BigNumber.ROUND_HALF_EVEN = 6;
+        global.api.BigNumber.ROUND_HALF_CEIL = 7;
+        global.api.BigNumber.ROUND_HALF_FLOOR = 8;
+        global.api.BigNumber.min = (...args) => bigNumberWrapper(_sscglobal_bn_min.applySync(undefined, args.map(maybeUnwrap)));
+        global.api.BigNumber.max = (...args) => bigNumberWrapper(_sscglobal_bn_max.applySync(undefined, args.map(maybeUnwrap)));
+      };
+
+      const compiledWrapper = await vm.isolate.compileScript(wrappedCode);
+      await compiledWrapper.run(vm.context);
+      await vm.context.global.delete('sscglobal_api');
+      await vm.context.global.delete('sscglobal_debug');
+      await vm.context.global.delete('sscglobal_db');
+      await vm.context.global.delete('sscglobal_externalCopy');
+      await vm.context.global.delete('sscglobal_bn_construct');
+      await vm.context.global.delete('sscglobal_bn_plus');
+      await vm.context.global.delete('sscglobal_bn_minus');
+      await vm.context.global.delete('sscglobal_bn_times');
+      await vm.context.global.delete('sscglobal_bn_multipliedBy');
+      await vm.context.global.delete('sscglobal_bn_dividedBy');
+      await vm.context.global.delete('sscglobal_bn_sqrt');
+      await vm.context.global.delete('sscglobal_bn_pow');
+      await vm.context.global.delete('sscglobal_bn_negated');
+      await vm.context.global.delete('sscglobal_bn_abs');
+      await vm.context.global.delete('sscglobal_bn_lt');
+      await vm.context.global.delete('sscglobal_bn_lte');
+      await vm.context.global.delete('sscglobal_bn_eq');
+      await vm.context.global.delete('sscglobal_bn_gt');
+      await vm.context.global.delete('sscglobal_bn_gte');
+      await vm.context.global.delete('sscglobal_bn_dp');
+      await vm.context.global.delete('sscglobal_bn_decimalPlaces');
+      await vm.context.global.delete('sscglobal_bn_isNaN');
+      await vm.context.global.delete('sscglobal_bn_isFinite');
+      await vm.context.global.delete('sscglobal_bn_isInteger');
+      await vm.context.global.delete('sscglobal_bn_isPositive');
+      await vm.context.global.delete('sscglobal_bn_toFixed');
+      await vm.context.global.delete('sscglobal_bn_toNumber');
+      await vm.context.global.delete('sscglobal_bn_toString');
+      await vm.context.global.delete('sscglobal_bn_integerValue');
+      await vm.context.global.delete('sscglobal_bn_min');
+      await vm.context.global.delete('sscglobal_bn_max');
+      const compiled = await vm.isolate.compileScript(contractCode);
+      await compiled.run(vm.context);
+      vm.inUse = false;
+      return contractError;
+    } else {
+      return 'no JS VM available';
+    }
   }
 
   static async executeSmartContractFromSmartContract(

--- a/libs/SmartContracts.js
+++ b/libs/SmartContracts.js
@@ -23,7 +23,7 @@ function deepDeref(x) {
         y[k] = deepDeref(y[k]);
     });
   } else if (typeof x === "array") {
-    y = x.map(deepDeref); 
+    y = x.map(deepDeref);
   }
   return maybeDeref(y);
 }
@@ -35,7 +35,7 @@ function deepConvertDecimal128(x) {
         y[k] = deepConvertDecimal128(y[k]);
     });
   } else if (typeof x === "array") {
-    y = x.map(deepConvertDecimal128); 
+    y = x.map(deepConvertDecimal128);
   }
   if (y instanceof BigNumber || y instanceof Decimal128) {
     y = new ivm.Reference(y);
@@ -85,11 +85,11 @@ class SmartContracts {
             RegExp.prototype.constructor = function () { };
             RegExp.prototype.exec = function () {  };
             RegExp.prototype.test = function () {  };
-  
+
             let actions = {};
-  
+
             ###ACTIONS###
-  
+
             const execute = async function () {
               try {
                 if (api.action && typeof api.action === 'string' && typeof actions[api.action] === 'function') {
@@ -105,7 +105,7 @@ class SmartContracts {
                 done(error);
               }
             }
-  
+
             execute();
           }
 
@@ -184,7 +184,6 @@ class SmartContracts {
             refHiveBlockNumber,
             hiveBlockTimestamp: timestamp,
             contractVersion,
-            //db,
             BigNumber: new ivm.Reference((x) => BigNumber(x)),
             SHA256: new ivm.Reference((payloadToHash) => {
               if (typeof payloadToHash === 'string') {
@@ -539,7 +538,6 @@ class SmartContracts {
         Object.assign(contractInDb.tables, tables);
         await database.updateContract(contractInDb);
       }
-
       return results;
     } catch (e) {
       log.error('ERROR DURING CONTRACT EXECUTION: ', e);
@@ -550,7 +548,7 @@ class SmartContracts {
   }
 
   static getJSVM(jsVMTimeout) {
-    const isolate = new ivm.Isolate({ memoryLimit: 128 });
+    const isolate = new ivm.Isolate({ memoryLimit: 256 });
     const context = isolate.createContextSync();
     return {
       timeout: jsVMTimeout,
@@ -834,6 +832,7 @@ class SmartContracts {
         }
       }
     } catch (error) {
+      log.warn(error);
       results.errors = [];
       results.errors.push(error);
     }

--- a/libs/SmartContracts.js
+++ b/libs/SmartContracts.js
@@ -40,7 +40,7 @@ function deepConvertDecimal128(x) {
   } else if (typeof x === "array") {
     y = x.map(deepConvertDecimal128); 
   }
-  return y instanceof Decimal128 ? BigNumber(y) : y;
+  return y instanceof Decimal128 ? BigNumber(y).toString() : y instanceof BigNumber ? y.toString() : y;
 }
 
 class SmartContracts {
@@ -97,17 +97,16 @@ class SmartContracts {
                     actions.createSSC = null;
                   }
                   await actions[api.action](api.payload);
-                  return null;
+                  done(null);
                 } else {
-                  return 'invalid action';
+                  done('invalid action');
                 }
               } catch (error) {
-                api.debug(error);
-                return 'error';
-             }
+                done(error);
+              }
             }
   
-            return execute();
+            execute();
           }
 
           wrapper();
@@ -224,7 +223,7 @@ class SmartContracts {
               name, 'createSSC', contractVersion,
             ))),
             // emit an event that will be stored in the logs
-            emit: new ivm.Reference((event, data) => typeof event === 'string' && logs.events.push({ contract: name, event, data })),
+            emit: new ivm.Reference((event, data) => typeof event === 'string' && logs.events.push({ contract: name, event, data: deepDeref(data) })),
             // add an error that will be stored in the logs
             assert: new ivm.Reference((condition, error) => {
               if (!condition && typeof error === 'string') {
@@ -477,7 +476,7 @@ class SmartContracts {
             JSON.stringify({
               from: contract,
               to,
-              quantity,
+              quantity: maybeDeref(quantity),
               symbol,
               type,
             }),
@@ -490,7 +489,7 @@ class SmartContracts {
             await SmartContracts.verifyBlock(database, block);
           }),
           // emit an event that will be stored in the logs
-          emit: new ivm.Reference((event, data) => typeof event === 'string' && results.logs.events.push({ contract, event, data })),
+          emit: new ivm.Reference((event, data) => typeof event === 'string' && results.logs.events.push({ contract, event, data: deepDeref(data) })),
           // add an error that will be stored in the logs
           assert: new ivm.Reference((condition, error) => {
             if (!condition && typeof error === 'string') {
@@ -513,7 +512,7 @@ class SmartContracts {
           JSON.stringify({
             from: payloadObj.callingContractInfo.name,
             to,
-            quantity,
+            quantity: maybeDeref(quantity),
             symbol,
             type,
           }),
@@ -555,7 +554,6 @@ class SmartContracts {
     const context = isolate.createContextSync();
     return {
       timeout: jsVMTimeout,
-      inUse: true,
       context,
       isolate
     };
@@ -565,169 +563,182 @@ class SmartContracts {
   static runContractCode(vmState, contractCode, jsVMTimeout) {
     return new Promise((resolve) => {
       const vm = SmartContracts.getJSVM(jsVMTimeout);
-      try {
-        // run the code in the VM
-        if (vm !== null) {
-          //vm.context.global.setSync('global', vm.context.global.derefInto());
-          //vm.context.global.setSync('api', new ivm.ExternalCopy(vmState.api));
-          vm.context.global.setSync('sscglobal_externalCopy', x => new ivm.ExternalCopy(x));
-          Object.keys(vmState.api).forEach((key) => {
-              vm.context.global.setSync('sscglobal_' + key, key === 'payload' && typeof(vmState.api[key]) === 'object' ? new ivm.ExternalCopy(vmState.api[key]) : vmState.api[key]);
-              });
-          Object.keys(vmState.db).forEach((key) => {
-              vm.context.global.setSync('sscglobal_' + key, vmState.db[key]);
-              });
-          vm.context.global.setSync('sscglobalv_isAlpha', new ivm.Callback(validator.isAlpha));
-          vm.context.global.setSync('sscglobalv_isAlphanumeric', new ivm.Callback(validator.isAlphanumeric));
-          vm.context.global.setSync('sscglobalv_blacklist', new ivm.Callback(validator.blacklist));
-          vm.context.global.setSync('sscglobalv_isUppercase', new ivm.Callback(validator.isUppercase));
+      // run the code in the VM
+      if (vm !== null) {
+        vm.context.global.setSync('done', (error) => {
+          resolve(error);
+        });
+        vm.context.global.setSync('sscglobal_externalCopy', x => new ivm.ExternalCopy(x));
+        Object.keys(vmState.api).forEach((key) => {
+            vm.context.global.setSync('sscglobal_' + key, key === 'payload' && typeof(vmState.api[key]) === 'object' ? new ivm.ExternalCopy(vmState.api[key]) : vmState.api[key]);
+            });
+        Object.keys(vmState.db).forEach((key) => {
+            vm.context.global.setSync('sscglobal_' + key, vmState.db[key]);
+            });
+        vm.context.global.setSync('sscglobalv_isAlpha', new ivm.Callback(validator.isAlpha));
+        vm.context.global.setSync('sscglobalv_isAlphanumeric', new ivm.Callback(validator.isAlphanumeric));
+        vm.context.global.setSync('sscglobalv_blacklist', new ivm.Callback(validator.blacklist));
+        vm.context.global.setSync('sscglobalv_isUppercase', new ivm.Callback(validator.isUppercase));
+        vm.context.global.setSync('sscglobalv_isIP', new ivm.Callback(validator.isIP));
+        vm.context.global.setSync('sscglobalv_isFQDN', new ivm.Callback(validator.isFQDN));
 
-          vm.context.global.setSync('sscglobal_bn_construct', new ivm.Reference((x, y) => BigNumber(maybeDeref(x))));
-          vm.context.global.setSync('sscglobal_bn_plus', new ivm.Reference((x, y) => x.deref().plus(maybeDeref(y))));
-          vm.context.global.setSync('sscglobal_bn_minus', new ivm.Reference((x, y) => x.deref().minus(maybeDeref(y))));
-          vm.context.global.setSync('sscglobal_bn_times', new ivm.Reference((x, y) => x.deref().times(maybeDeref(y))));
-          vm.context.global.setSync('sscglobal_bn_multipliedBy', new ivm.Reference((x, y, z) => x.deref().multipliedBy(maybeDeref(y), z)));
-          vm.context.global.setSync('sscglobal_bn_dividedBy', new ivm.Reference((x, y, z) => x.deref().dividedBy(maybeDeref(y), z)));
-          vm.context.global.setSync('sscglobal_bn_sqrt', new ivm.Reference((x) => x.deref().sqrt()));
-          vm.context.global.setSync('sscglobal_bn_pow', new ivm.Reference((x, y) => x.deref().pow(y)));
-          vm.context.global.setSync('sscglobal_bn_negated', new ivm.Reference((x) => x.deref().negated()));
-          vm.context.global.setSync('sscglobal_bn_lt', new ivm.Reference((x, y) => x.deref().lt(maybeDeref(y))));
-          vm.context.global.setSync('sscglobal_bn_lte', new ivm.Reference((x, y) => x.deref().lte(maybeDeref(y))));
-          vm.context.global.setSync('sscglobal_bn_eq', new ivm.Reference((x, y) => x.deref().eq(maybeDeref(y))));
-          vm.context.global.setSync('sscglobal_bn_gt', new ivm.Reference((x, y) => x.deref().gt(maybeDeref(y))));
-          vm.context.global.setSync('sscglobal_bn_gte', new ivm.Reference((x, y) => x.deref().gte(maybeDeref(y))));
-          vm.context.global.setSync('sscglobal_bn_dp', new ivm.Reference((x, y, z) => x.deref().dp(y, z)));
-          vm.context.global.setSync('sscglobal_bn_isNaN', new ivm.Reference((x) => x.deref().isNaN()));
-          vm.context.global.setSync('sscglobal_bn_isFinite', new ivm.Reference((x) => x.deref().isFinite()));
-          vm.context.global.setSync('sscglobal_bn_isInteger', new ivm.Reference((x) => x.deref().isInteger()));
-          vm.context.global.setSync('sscglobal_bn_toFixed', new ivm.Reference((x, y, z) => x.deref().toFixed(y, z)));
-          vm.context.global.setSync('sscglobal_bn_toNumber', new ivm.Reference((x) => x.deref().toNumber()));
-          vm.context.global.setSync('sscglobal_bn_integerValue', new ivm.Reference((x, y) => x.deref().integerValue(y)));
+        vm.context.global.setSync('sscglobal_bn_construct', new ivm.Reference((x, y) => BigNumber(maybeDeref(x))));
+        vm.context.global.setSync('sscglobal_bn_plus', new ivm.Reference((x, y) => x.deref().plus(maybeDeref(y))));
+        vm.context.global.setSync('sscglobal_bn_minus', new ivm.Reference((x, y) => x.deref().minus(maybeDeref(y))));
+        vm.context.global.setSync('sscglobal_bn_times', new ivm.Reference((x, y) => x.deref().times(maybeDeref(y))));
+        vm.context.global.setSync('sscglobal_bn_multipliedBy', new ivm.Reference((x, y, z) => x.deref().multipliedBy(maybeDeref(y), z)));
+        vm.context.global.setSync('sscglobal_bn_dividedBy', new ivm.Reference((x, y, z) => x.deref().dividedBy(maybeDeref(y), z)));
+        vm.context.global.setSync('sscglobal_bn_sqrt', new ivm.Reference((x) => x.deref().sqrt()));
+        vm.context.global.setSync('sscglobal_bn_pow', new ivm.Reference((x, y) => x.deref().pow(maybeDeref(y))));
+        vm.context.global.setSync('sscglobal_bn_negated', new ivm.Reference((x) => x.deref().negated()));
+        vm.context.global.setSync('sscglobal_bn_abs', new ivm.Reference((x) => x.deref().abs()));
+        vm.context.global.setSync('sscglobal_bn_lt', new ivm.Reference((x, y) => x.deref().lt(maybeDeref(y))));
+        vm.context.global.setSync('sscglobal_bn_lte', new ivm.Reference((x, y) => x.deref().lte(maybeDeref(y))));
+        vm.context.global.setSync('sscglobal_bn_eq', new ivm.Reference((x, y) => x.deref().eq(maybeDeref(y))));
+        vm.context.global.setSync('sscglobal_bn_gt', new ivm.Reference((x, y) => x.deref().gt(maybeDeref(y))));
+        vm.context.global.setSync('sscglobal_bn_gte', new ivm.Reference((x, y) => x.deref().gte(maybeDeref(y))));
+        vm.context.global.setSync('sscglobal_bn_dp', new ivm.Reference((x, y, z) => x.deref().dp(y, z)));
+        vm.context.global.setSync('sscglobal_bn_decimalPlaces', new ivm.Reference((x, y, z) => x.deref().decimalPlaces(y, z)));
+        vm.context.global.setSync('sscglobal_bn_isNaN', new ivm.Reference((x) => x.deref().isNaN()));
+        vm.context.global.setSync('sscglobal_bn_isFinite', new ivm.Reference((x) => x.deref().isFinite()));
+        vm.context.global.setSync('sscglobal_bn_isInteger', new ivm.Reference((x) => x.deref().isInteger()));
+        vm.context.global.setSync('sscglobal_bn_isPositive', new ivm.Reference((x) => x.deref().isPositive()));
+        vm.context.global.setSync('sscglobal_bn_toFixed', new ivm.Reference((x, y, z) => x.deref().toFixed(y, z)));
+        vm.context.global.setSync('sscglobal_bn_toNumber', new ivm.Reference((x) => x.deref().toNumber()));
+        vm.context.global.setSync('sscglobal_bn_toString', new ivm.Reference((x) => x.deref().toString()));
+        vm.context.global.setSync('sscglobal_bn_integerValue', new ivm.Reference((x, y) => x.deref().integerValue(y)));
+        vm.context.global.setSync('sscglobal_bn_min', new ivm.Reference((...args) => BigNumber.min.apply(undefined, args.map(maybeDeref))));
+        vm.context.global.setSync('sscglobal_bn_max', new ivm.Reference((...args) => BigNumber.max.apply(undefined, args.map(maybeDeref))));
 
-          const wrappedCode = `
-          function deepUnwrap(x) {
-            let y = x;
-            if (typeof x === "object" && x !== null) {
-              Object.keys(x).forEach(k => {
-                  y[k] = deepUnwrap(y[k]);
-              });
-            } else if (typeof x === "array") {
-              y = x.map(deepUnwrap); 
-            }
-            return maybeUnwrap(y);
+        const wrappedCode = `
+        function deepUnwrap(x) {
+          let y = x;
+          if (typeof x === "object" && x !== null) {
+            Object.keys(x).forEach(k => {
+                y[k] = deepUnwrap(y[k]);
+            });
+          } else if (typeof x === "array") {
+            y = x.map(deepUnwrap);
           }
-          function applyWrapper(fn) {
-            return async (...args) => {
-              const extArgs = args.map(x => sscglobal_externalCopy(deepUnwrap(x)).copyInto());
-              const result = await fn.applySyncPromise(undefined, extArgs);
-              return (typeof result === 'object' && result.copy) ? await result.copy() : result;
-            }
-          }
-          function applyWrapperSync(fn) {
-            return (...args) => {
-api.debug(args);
-              const extArgs = args.map(x => sscglobal_externalCopy(deepUnwrap(x)).copyInto());
-              const result = fn.applySync(undefined, extArgs);
-              return (typeof result === 'object' && result.copy) ? result.copy() : result;
-            }
-          }
-          function maybeUnwrap(x) {
-            return typeof x === 'object' && x !== null && x.unwrap ? x.unwrap() : x;
-          }
-          function makeBigNumber(x) {
-            return bigNumberWrapper(sscglobal_bn_construct.applySync(undefined, [maybeUnwrap(x)]));
-          }
-          function bigNumberWrapper(x) {
-            return {
-              plus: (y) => bigNumberWrapper(sscglobal_bn_plus.applySync(undefined,[x, maybeUnwrap(y)])),
-              minus: (y) => bigNumberWrapper(sscglobal_bn_minus.applySync(undefined,[x, maybeUnwrap(y)])),
-              times: (y) => bigNumberWrapper(sscglobal_bn_times.applySync(undefined,[x, maybeUnwrap(y)])),
-              multipliedBy: (y, z) => bigNumberWrapper(sscglobal_bn_multipliedBy.applySync(undefined,[x, maybeUnwrap(y), z])),
-              dividedBy: (y, z) => bigNumberWrapper(sscglobal_bn_dividedBy.applySync(undefined,[x, maybeUnwrap(y), z])),
-              sqrt: () => bigNumberWrapper(sscglobal_bn_sqrt.applySync(undefined,[x])),
-              pow: (y) => bigNumberWrapper(sscglobal_bn_sqrt.applySync(undefined,[x, y])),
-              negated: () => bigNumberWrapper(sscglobal_bn_negated.applySync(undefined,[x])),
-              lt: (y) => sscglobal_bn_lt.applySync(undefined, [x, maybeUnwrap(y)]),
-              lte: (y) => sscglobal_bn_lte.applySync(undefined, [x, maybeUnwrap(y)]),
-              eq: (y) => sscglobal_bn_eq.applySync(undefined, [x, maybeUnwrap(y)]),
-              gt: (y) => sscglobal_bn_gt.applySync(undefined, [x, maybeUnwrap(y)]),
-              gte: (y) => sscglobal_bn_gte.applySync(undefined, [x, maybeUnwrap(y)]),
-              dp: (y, z) => { const ret = sscglobal_bn_dp.applySync(undefined, [x, y, z]);
-                return typeof y === 'number' ? bigNumberWrapper(ret) : ret;
-              },
-              isNaN: () => sscglobal_bn_isNaN.applySync(undefined, [x]),
-              isFinite: () => sscglobal_bn_isFinite.applySync(undefined, [x]),
-              isInteger: () => sscglobal_bn_isInteger.applySync(undefined, [x]),
-              toFixed: (y, z) => sscglobal_bn_toFixed.applySync(undefined, [x, y, z]),
-              toNumber: () => sscglobal_bn_toNumber.applySync(undefined, [x]),
-              integerValue: (y) => sscglobal_bn_integerValue.applySync(undefined, [x, y]),
-              unwrap: () => x,
-            };
-          }
-          const api = {
-            sender: typeof sscglobal_sender !== 'undefined' ? sscglobal_sender : null,
-            owner: typeof sscglobal_owner !== 'undefined' ? sscglobal_owner : null,
-            action: sscglobal_action,
-            payload: typeof sscglobal_payload === 'object' && sscglobal_payload.copy ? sscglobal_payload.copy() : sscglobal_payload,
-            transactionId: sscglobal_transactionId,
-            blockNumber: sscglobal_blockNumber,
-            refHiveBlockNumber: sscglobal_refHiveBlockNumber,
-            hiveBlockTimestamp: sscglobal_hiveBlockTimestamp,
-            contractVersion: sscglobal_contractVersion,
-            db: {
-              createTable: typeof sscglobal_createTable !== 'undefined' ? applyWrapper(sscglobal_createTable) : null,
-              addIndexes: typeof sscglobal_addIndexes !== 'undefined' ? applyWrapper(sscglobal_addIndexes) : null,
-              find: applyWrapper(sscglobal_find),
-              findInTable: applyWrapper(sscglobal_findInTable),
-              findOne: applyWrapper(sscglobal_findOne),
-              findOneInTable: applyWrapper(sscglobal_findOneInTable),
-              findContract: applyWrapper(sscglobal_findContract),
-              insert: applyWrapper(sscglobal_insert),
-              remove: applyWrapper(sscglobal_remove),
-              update: applyWrapper(sscglobal_update),
-              tableExists: applyWrapper(sscglobal_tableExists),
-            },
-            BigNumber: makeBigNumber,
-            validator: {
-              isAlpha: sscglobalv_isAlpha,
-              isAlphanumeric: sscglobalv_isAlphanumeric,
-              blacklist: sscglobalv_blacklist,
-              isUppercase: sscglobalv_isUppercase,
-            },
-            logs: typeof sscglobal_logs !== 'undefined' ? sscglobal_logs : null,
-            SHA256: sscglobal_SHA256,
-            checkSignature: sscglobal_checkSignature,
-            random: sscglobal_random,
-            debug: sscglobal_debug,
-            executeSmartContract: applyWrapper(sscglobal_executeSmartContract),
-            executeSmartContractAsOwner: typeof sscglobal_executeSmartContractAsOwner !== 'undefined' ? applyWrapper(sscglobal_executeSmartContractAsOwner) : null,
-            transferTokens: typeof sscglobal_transferTokens !== 'undefined' ? applyWrapper(sscglobal_transferTokens) : null,
-            transferTokensFromCallingContract: typeof sscglobal_transferTokensFromCallingContract !== 'undefined' ? applyWrapper(sscglobal_transferTokensFromCallingContract) : null, 
-            verifyBlock: typeof sscglobal_verifyBlock !== 'undefined' ? applyWrapper(sscglobal_verifyBlock) : null,
-            emit: applyWrapper(sscglobal_emit),
-            assert: applyWrapperSync(sscglobal_assert),
-            isValidAccountName: applyWrapperSync(sscglobal_isValidAccountName),
-            };
-            api.BigNumber.ROUND_UP = 0;
-            api.BigNumber.ROUND_DOWN = 1;
-            api.BigNumber.ROUND_CEIL = 2;
-            api.BigNumber.ROUND_FLOOR = 3;
-            api.BigNumber.ROUND_HALF_UP = 4;
-            api.BigNumber.ROUND_HALF_DOWN = 5;
-            api.BigNumber.ROUND_HALF_EVEN = 6;
-            api.BigNumber.ROUND_HALF_CEIL = 7;
-            api.BigNumber.ROUND_HALF_FLOOR = 8;
-          ` + contractCode;
-          const compiled = vm.isolate.compileScriptSync(wrappedCode);
-          compiled.run(vm.context).then((x) => resolve()).catch((err) => { log.warn(err); resolve(err)});
-        } else {
-log.warn('no js vm available');
-          resolve('no JS VM available');
+          return maybeUnwrap(y);
         }
-      } catch (err) {
-        log.warn(err);
-        vm.inUse = false;
-        resolve(err);
+        function applyWrapper(fn) {
+          return async (...args) => {
+            const extArgs = args.map(x => sscglobal_externalCopy(deepUnwrap(x)).copyInto());
+            const result = await fn.applySyncPromise(undefined, extArgs);
+            return (typeof result === 'object' && result.copy) ? await result.copy() : result;
+          }
+        }
+        function applyWrapperSync(fn) {
+          return (...args) => {
+            const extArgs = args.map(x => sscglobal_externalCopy(deepUnwrap(x)).copyInto());
+            const result = fn.applySync(undefined, extArgs);
+            return (typeof result === 'object' && result.copy) ? result.copy() : result;
+          }
+        }
+        function maybeUnwrap(x) {
+          return typeof x === 'object' && x !== null && x.unwrap ? x.unwrap() : x;
+        }
+        function makeBigNumber(x) {
+          return bigNumberWrapper(sscglobal_bn_construct.applySync(undefined, [maybeUnwrap(x)]));
+        }
+        function bigNumberWrapper(x) {
+          return {
+            plus: (y) => bigNumberWrapper(sscglobal_bn_plus.applySync(undefined,[x, maybeUnwrap(y)])),
+            minus: (y) => bigNumberWrapper(sscglobal_bn_minus.applySync(undefined,[x, maybeUnwrap(y)])),
+            times: (y) => bigNumberWrapper(sscglobal_bn_times.applySync(undefined,[x, maybeUnwrap(y)])),
+            multipliedBy: (y, z) => bigNumberWrapper(sscglobal_bn_multipliedBy.applySync(undefined,[x, maybeUnwrap(y), z])),
+            dividedBy: (y, z) => bigNumberWrapper(sscglobal_bn_dividedBy.applySync(undefined,[x, maybeUnwrap(y), z])),
+            sqrt: () => bigNumberWrapper(sscglobal_bn_sqrt.applySync(undefined,[x])),
+            pow: (y) => bigNumberWrapper(sscglobal_bn_pow.applySync(undefined,[x, maybeUnwrap(y)])),
+            negated: () => bigNumberWrapper(sscglobal_bn_negated.applySync(undefined,[x])),
+            abs: () => bigNumberWrapper(sscglobal_bn_abs.applySync(undefined,[x])),
+            lt: (y) => sscglobal_bn_lt.applySync(undefined, [x, maybeUnwrap(y)]),
+            lte: (y) => sscglobal_bn_lte.applySync(undefined, [x, maybeUnwrap(y)]),
+            eq: (y) => sscglobal_bn_eq.applySync(undefined, [x, maybeUnwrap(y)]),
+            gt: (y) => sscglobal_bn_gt.applySync(undefined, [x, maybeUnwrap(y)]),
+            gte: (y) => sscglobal_bn_gte.applySync(undefined, [x, maybeUnwrap(y)]),
+            dp: (y, z) => { const ret = sscglobal_bn_dp.applySync(undefined, [x, y, z]);
+              return typeof y === 'number' ? bigNumberWrapper(ret) : ret;
+            },
+            decimalPlaces: (y, z) => { const ret = sscglobal_bn_decimalPlaces.applySync(undefined, [x, y, z]);
+              return typeof y === 'number' ? bigNumberWrapper(ret) : ret;
+            },
+            isNaN: () => sscglobal_bn_isNaN.applySync(undefined, [x]),
+            isFinite: () => sscglobal_bn_isFinite.applySync(undefined, [x]),
+            isInteger: () => sscglobal_bn_isInteger.applySync(undefined, [x]),
+            isPositive: () => sscglobal_bn_isPositive.applySync(undefined, [x]),
+            toFixed: (y, z) => sscglobal_bn_toFixed.applySync(undefined, [x, y, z]),
+            toNumber: () => sscglobal_bn_toNumber.applySync(undefined, [x]),
+            toString: () => sscglobal_bn_toString.applySync(undefined, [x]),
+            integerValue: (y) => bigNumberWrapper(sscglobal_bn_integerValue.applySync(undefined, [x, y])),
+            unwrap: () => x,
+            [Symbol.toPrimitive]: () => sscglobal_bn_toNumber.applySync(undefined, [x]),
+          };
+        }
+        const api = {
+          sender: typeof sscglobal_sender !== 'undefined' ? sscglobal_sender : null,
+          owner: typeof sscglobal_owner !== 'undefined' ? sscglobal_owner : null,
+          action: sscglobal_action,
+          payload: typeof sscglobal_payload === 'object' && sscglobal_payload.copy ? sscglobal_payload.copy() : sscglobal_payload,
+          transactionId: sscglobal_transactionId,
+          blockNumber: sscglobal_blockNumber,
+          refHiveBlockNumber: sscglobal_refHiveBlockNumber,
+          hiveBlockTimestamp: sscglobal_hiveBlockTimestamp,
+          contractVersion: sscglobal_contractVersion,
+          db: {
+            createTable: typeof sscglobal_createTable !== 'undefined' ? applyWrapper(sscglobal_createTable) : null,
+            addIndexes: typeof sscglobal_addIndexes !== 'undefined' ? applyWrapper(sscglobal_addIndexes) : null,
+            find: applyWrapper(sscglobal_find),
+            findInTable: applyWrapper(sscglobal_findInTable),
+            findOne: applyWrapper(sscglobal_findOne),
+            findOneInTable: applyWrapper(sscglobal_findOneInTable),
+            findContract: applyWrapper(sscglobal_findContract),
+            insert: applyWrapper(sscglobal_insert),
+            remove: applyWrapper(sscglobal_remove),
+            update: applyWrapper(sscglobal_update),
+            tableExists: applyWrapper(sscglobal_tableExists),
+            getBlockInfo: typeof sscglobal_getBlockInfo !== 'undefined' ? applyWrapper(sscglobal_getBlockInfo) : null,
+          },
+          BigNumber: makeBigNumber,
+          validator: {
+            isAlpha: sscglobalv_isAlpha,
+            isAlphanumeric: sscglobalv_isAlphanumeric,
+            blacklist: sscglobalv_blacklist,
+            isUppercase: sscglobalv_isUppercase,
+            isIP: sscglobalv_isIP,
+            isFQDN: sscglobalv_isFQDN,
+          },
+          logs: typeof sscglobal_logs !== 'undefined' ? applyWrapperSync(sscglobal_logs) : null,
+          SHA256: applyWrapperSync(sscglobal_SHA256),
+          checkSignature: applyWrapperSync(sscglobal_checkSignature),
+          random: applyWrapperSync(sscglobal_random),
+          debug: sscglobal_debug,
+          executeSmartContract: applyWrapper(sscglobal_executeSmartContract),
+          executeSmartContractAsOwner: typeof sscglobal_executeSmartContractAsOwner !== 'undefined' ? applyWrapper(sscglobal_executeSmartContractAsOwner) : null,
+          transferTokens: typeof sscglobal_transferTokens !== 'undefined' ? applyWrapper(sscglobal_transferTokens) : null,
+          transferTokensFromCallingContract: typeof sscglobal_transferTokensFromCallingContract !== 'undefined' ? applyWrapper(sscglobal_transferTokensFromCallingContract) : null,
+          verifyBlock: typeof sscglobal_verifyBlock !== 'undefined' ? applyWrapper(sscglobal_verifyBlock) : null,
+          emit: applyWrapper(sscglobal_emit),
+          assert: (condition, message) => sscglobal_assert.applySync(undefined, [!!condition, message]).copy(),
+          isValidAccountName: applyWrapperSync(sscglobal_isValidAccountName),
+          };
+          api.BigNumber.ROUND_UP = 0;
+          api.BigNumber.ROUND_DOWN = 1;
+          api.BigNumber.ROUND_CEIL = 2;
+          api.BigNumber.ROUND_FLOOR = 3;
+          api.BigNumber.ROUND_HALF_UP = 4;
+          api.BigNumber.ROUND_HALF_DOWN = 5;
+          api.BigNumber.ROUND_HALF_EVEN = 6;
+          api.BigNumber.ROUND_HALF_CEIL = 7;
+          api.BigNumber.ROUND_HALF_FLOOR = 8;
+          api.BigNumber.min = (...args) => bigNumberWrapper(sscglobal_bn_min.applySync(undefined, args.map(maybeUnwrap)));
+          api.BigNumber.max = (...args) => bigNumberWrapper(sscglobal_bn_max.applySync(undefined, args.map(maybeUnwrap)));
+        ` + contractCode;
+        const compiled = vm.isolate.compileScriptSync(wrappedCode);
+        compiled.run(vm.context);
+      } else {
+        resolve('no JS VM available');
       }
     });
   }
@@ -931,12 +942,11 @@ log.warn('no js vm available');
     const result = await database.find({
       contract: contractName,
       table,
-      query,
+      query: deepDeref(query),
       limit,
       offset,
       indexes,
     });
-
     return typeof result === 'array' ? result.map(deepConvertDecimal128) : result;
   }
 
@@ -944,7 +954,7 @@ log.warn('no js vm available');
     const result = await database.findOne({
       contract: contractName,
       table,
-      query,
+      query: deepDeref(query),
     });
 
     return deepConvertDecimal128(result);

--- a/libs/util/testing/Fixture.js
+++ b/libs/util/testing/Fixture.js
@@ -13,6 +13,7 @@ const conf = {
   databaseURL: 'mongodb://localhost:27017',
   databaseName: 'testssc',
   streamNodes: ['https://api.hive.blog'],
+  defaultLogLevel: "info",
 };
 
 class Fixture {
@@ -89,8 +90,10 @@ class Fixture {
   }
 
   unloadPlugin(plugin) {
-    this.plugins[plugin.PLUGIN_NAME].cp.kill('SIGINT');
-    this.plugins[plugin.PLUGIN_NAME] = null;
+    if (this.plugins[plugin.PLUGIN_NAME]) {
+      this.plugins[plugin.PLUGIN_NAME].cp.kill('SIGINT');
+      this.plugins[plugin.PLUGIN_NAME] = null;
+    }
   }
 
   getNextTxId() {

--- a/libs/util/testing/Fixture.js
+++ b/libs/util/testing/Fixture.js
@@ -13,7 +13,7 @@ const conf = {
   databaseURL: 'mongodb://localhost:27017',
   databaseName: 'testssc',
   streamNodes: ['https://api.hive.blog'],
-  defaultLogLevel: "info",
+  defaultLogLevel: "warn",
 };
 
 class Fixture {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "dotenv": "^6.2.0",
         "express": "^4.18.2",
         "fs-extra": "^6.0.1",
+        "isolated-vm": "^4.7.2",
         "jayson": "^4.1.2",
         "js-base64": "^2.6.4",
         "line-by-line": "^0.1.6",
@@ -29,7 +30,6 @@
         "read-last-lines": "^1.8.0",
         "seedrandom": "^3.0.5",
         "validator": "^10.11.0",
-        "vm2": "^3.9.2",
         "winston": "^3.3.3"
       },
       "devDependencies": {
@@ -41,8 +41,8 @@
         "mocha": "^7.2.0"
       },
       "engines": {
-        "node": ">=v18.17.0",
-        "npm": ">=9.6.7"
+        "node": ">=v16.15.0",
+        "npm": ">=6.13.6"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -633,6 +633,11 @@
         "fsevents": "~2.1.1"
       }
     },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+    },
     "node_modules/cipher-base": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
@@ -936,6 +941,28 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -988,6 +1015,14 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
+      "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/diff": {
@@ -1068,6 +1103,14 @@
       "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/error-ex": {
@@ -1501,6 +1544,14 @@
         "safe-buffer": "^5.1.1"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/express": {
       "version": "4.18.2",
       "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
@@ -1787,6 +1838,11 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+    },
     "node_modules/fs-extra": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
@@ -1845,6 +1901,11 @@
         "has": "^1.0.3",
         "has-symbols": "^1.0.1"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="
     },
     "node_modules/glob": {
       "version": "7.1.6",
@@ -2076,6 +2137,11 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+    },
     "node_modules/inquirer": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
@@ -2296,6 +2362,18 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
+    },
+    "node_modules/isolated-vm": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/isolated-vm/-/isolated-vm-4.7.2.tgz",
+      "integrity": "sha512-JVEs5gzWObzZK5+OlBplCdYSpokMcdhLSs/xWYYxmYWVfOOFF4oZJsYh7E/FmfX8e7gMioXMpMMeEyX1afuKrg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
     },
     "node_modules/isomorphic-ws": {
       "version": "4.0.1",
@@ -2644,6 +2722,17 @@
         "node": ">=4"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -2669,8 +2758,7 @@
     "node_modules/minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "node_modules/mkdirp": {
       "version": "0.5.5",
@@ -2683,6 +2771,11 @@
       "bin": {
         "mkdirp": "bin/cmd.js"
       }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
     },
     "node_modules/mocha": {
       "version": "7.2.0",
@@ -2931,6 +3024,11 @@
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
       "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ=="
     },
+    "node_modules/napi-build-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
+      "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg=="
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -2950,6 +3048,28 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "node_modules/node-abi": {
+      "version": "3.71.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.71.0.tgz",
+      "integrity": "sha512-SZ40vRiy/+wRTf21hxkkEjPJZpARzUMVcJoQse2EF8qkUWbbO2z7vd5oA/H6bVH6SZQ5STGcu0KRDS7biNRfxw==",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-abi/node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/node-environment-flags": {
       "version": "1.0.6",
@@ -3118,7 +3238,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -3320,6 +3439,31 @@
         "node": ">=4"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.2.tgz",
+      "integrity": "sha512-UnNke3IQb6sgarcZIDU3gbMeTp/9SSU1DAIkil7PrqG1vZlBtY5msYccSKSHDqa3hNg436IXK+SNImReuA1wEQ==",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^1.0.1",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -3366,6 +3510,15 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/pump": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
+      "integrity": "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -3409,6 +3562,20 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
       }
     },
     "node_modules/react-is": {
@@ -3768,6 +3935,49 @@
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/simple-swizzle": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
@@ -3939,7 +4149,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4004,6 +4213,55 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tar-stream/node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/tar-stream/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/text-hex": {
@@ -4095,6 +4353,17 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/type-check": {
       "version": "0.3.2",
@@ -4203,17 +4472,6 @@
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
-      }
-    },
-    "node_modules/vm2": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.2.tgz",
-      "integrity": "sha512-nzyFmHdy2FMg7mYraRytc2jr4QBaUY3TEGe3q3bK8EgS9WC98wxn2jrPxS/ruWm+JGzrEIIeufKweQzVoQEd+Q==",
-      "bin": {
-        "vm2": "bin/vm2"
-      },
-      "engines": {
-        "node": ">=6.0"
       }
     },
     "node_modules/whatwg-fetch": {
@@ -4367,8 +4625,7 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "node_modules/write": {
       "version": "1.0.3",
@@ -5049,6 +5306,11 @@
         "readdirp": "~3.2.0"
       }
     },
+    "chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+    },
     "cipher-base": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
@@ -5306,6 +5568,19 @@
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
     },
+    "decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "requires": {
+        "mimic-response": "^3.1.0"
+      }
+    },
+    "deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
+    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -5340,6 +5615,11 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
       "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg=="
+    },
+    "detect-libc": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
+      "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw=="
     },
     "diff": {
       "version": "3.5.0",
@@ -5405,6 +5685,14 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w=="
+    },
+    "end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "requires": {
+        "once": "^1.4.0"
+      }
     },
     "error-ex": {
       "version": "1.3.2",
@@ -5767,6 +6055,11 @@
         "safe-buffer": "^5.1.1"
       }
     },
+    "expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="
+    },
     "express": {
       "version": "4.18.2",
       "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
@@ -5992,6 +6285,11 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="
     },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+    },
     "fs-extra": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
@@ -6041,6 +6339,11 @@
         "has": "^1.0.3",
         "has-symbols": "^1.0.1"
       }
+    },
+    "github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="
     },
     "glob": {
       "version": "7.1.6",
@@ -6226,6 +6529,11 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
+    "ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+    },
     "inquirer": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
@@ -6394,6 +6702,14 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
+    },
+    "isolated-vm": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/isolated-vm/-/isolated-vm-4.7.2.tgz",
+      "integrity": "sha512-JVEs5gzWObzZK5+OlBplCdYSpokMcdhLSs/xWYYxmYWVfOOFF4oZJsYh7E/FmfX8e7gMioXMpMMeEyX1afuKrg==",
+      "requires": {
+        "prebuild-install": "^7.1.1"
+      }
     },
     "isomorphic-ws": {
       "version": "4.0.1",
@@ -6669,6 +6985,11 @@
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
       "dev": true
     },
+    "mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="
+    },
     "minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -6691,8 +7012,7 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mkdirp": {
       "version": "0.5.5",
@@ -6702,6 +7022,11 @@
       "requires": {
         "minimist": "^1.2.5"
       }
+    },
+    "mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
     },
     "mocha": {
       "version": "7.2.0",
@@ -6908,6 +7233,11 @@
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
       "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ=="
     },
+    "napi-build-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
+      "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg=="
+    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -6924,6 +7254,21 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "node-abi": {
+      "version": "3.71.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.71.0.tgz",
+      "integrity": "sha512-SZ40vRiy/+wRTf21hxkkEjPJZpARzUMVcJoQse2EF8qkUWbbO2z7vd5oA/H6bVH6SZQ5STGcu0KRDS7biNRfxw==",
+      "requires": {
+        "semver": "^7.3.5"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.6.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+          "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A=="
+        }
+      }
     },
     "node-environment-flags": {
       "version": "1.0.6",
@@ -7058,7 +7403,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -7212,6 +7556,25 @@
         "find-up": "^2.1.0"
       }
     },
+    "prebuild-install": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.2.tgz",
+      "integrity": "sha512-UnNke3IQb6sgarcZIDU3gbMeTp/9SSU1DAIkil7PrqG1vZlBtY5msYccSKSHDqa3hNg436IXK+SNImReuA1wEQ==",
+      "requires": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^1.0.1",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      }
+    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -7249,6 +7612,15 @@
         "ipaddr.js": "1.9.1"
       }
     },
+    "pump": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
+      "integrity": "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==",
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -7277,6 +7649,17 @@
         "http-errors": "2.0.0",
         "iconv-lite": "0.4.24",
         "unpipe": "1.0.0"
+      }
+    },
+    "rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "requires": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
       }
     },
     "react-is": {
@@ -7579,6 +7962,21 @@
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
     },
+    "simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="
+    },
+    "simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "requires": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "simple-swizzle": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
@@ -7733,8 +8131,7 @@
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-      "dev": true
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
     },
     "supports-color": {
       "version": "5.5.0",
@@ -7781,6 +8178,51 @@
           "dev": true,
           "requires": {
             "ansi-regex": "^4.1.0"
+          }
+        }
+      }
+    },
+    "tar-fs": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+      "requires": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "requires": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "dependencies": {
+        "bl": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+          "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+          "requires": {
+            "buffer": "^5.5.0",
+            "inherits": "^2.0.4",
+            "readable-stream": "^3.4.0"
+          }
+        },
+        "readable-stream": {
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+          "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
           }
         }
       }
@@ -7863,6 +8305,14 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
     },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
@@ -7944,11 +8394,6 @@
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
       }
-    },
-    "vm2": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.2.tgz",
-      "integrity": "sha512-nzyFmHdy2FMg7mYraRytc2jr4QBaUY3TEGe3q3bK8EgS9WC98wxn2jrPxS/ruWm+JGzrEIIeufKweQzVoQEd+Q=="
     },
     "whatwg-fetch": {
       "version": "3.6.2",
@@ -8080,8 +8525,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
       "version": "1.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hivesmartcontracts",
-  "version": "2.0.2",
+  "version": "ivm-1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hivesmartcontracts",
-      "version": "2.0.2",
+      "version": "ivm-1.0.0",
       "license": "MIT",
       "dependencies": {
         "@hiveio/dhive": "^1.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,8 +41,8 @@
         "mocha": "^7.2.0"
       },
       "engines": {
-        "node": ">=v16.15.0",
-        "npm": ">=6.13.6"
+        "node": ">=v18.17.0",
+        "npm": ">=9.6.7"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hivesmartcontracts",
-  "version": "2.0.2",
+  "version": "ivm-1.0.0",
   "description": "",
   "main": "app.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "test21": "./node_modules/mocha/bin/mocha ./test/beedollar.js --exit"
   },
   "engines": {
-    "node": ">=v18.17.0",
-    "npm": ">=9.6.7"
+    "node": ">=v16.15.0",
+    "npm": ">=6.13.6"
   },
   "keywords": [],
   "author": "Harpagon210 <harpagon210@gmail.com>",
@@ -50,6 +50,7 @@
     "dotenv": "^6.2.0",
     "express": "^4.18.2",
     "fs-extra": "^6.0.1",
+    "isolated-vm": "^4.7.2",
     "jayson": "^4.1.2",
     "js-base64": "^2.6.4",
     "line-by-line": "^0.1.6",
@@ -59,7 +60,6 @@
     "read-last-lines": "^1.8.0",
     "seedrandom": "^3.0.5",
     "validator": "^10.11.0",
-    "vm2": "^3.9.2",
     "winston": "^3.3.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "test21": "./node_modules/mocha/bin/mocha ./test/beedollar.js --exit"
   },
   "engines": {
-    "node": ">=v16.15.0",
-    "npm": ">=6.13.6"
+    "node": ">=v18.17.0",
+    "npm": ">=9.6.7"
   },
   "keywords": [],
   "author": "Harpagon210 <harpagon210@gmail.com>",

--- a/test/airdrops.js
+++ b/test/airdrops.js
@@ -75,6 +75,7 @@ describe('Airdrops Smart Contract', function () {
   afterEach((done) => {
     // runs after each test in this block
     new Promise(async (resolve) => {
+      fixture.tearDown();
       await db.dropDatabase();
       resolve();
     })

--- a/test/beedollar.js
+++ b/test/beedollar.js
@@ -58,6 +58,7 @@ describe('beedollar', function () {
   afterEach((done) => {
     // runs after each test in this block
     new Promise(async (resolve) => {
+      fixture.tearDown();
       await db.dropDatabase()
       resolve();
     })

--- a/test/botcontroller.js
+++ b/test/botcontroller.js
@@ -126,6 +126,7 @@ describe('botcontroller', function() {
   afterEach((done) => {
       // runs after each test in this block
       new Promise(async (resolve) => {
+        fixture.tearDown();
         await db.dropDatabase()
         resolve();
       })

--- a/test/claimdrops.js
+++ b/test/claimdrops.js
@@ -102,6 +102,7 @@ describe('Claimdrops Smart Contract', function () {
   afterEach((done) => {
     // runs after each test in this block
     new Promise(async (resolve) => {
+      fixture.tearDown();
       await db.dropDatabase();
       resolve();
     })

--- a/test/comments.js
+++ b/test/comments.js
@@ -353,6 +353,7 @@ describe('comments', function () {
   afterEach((done) => {
       // runs after each test in this block
       new Promise(async (resolve) => {
+        fixture.tearDown();
         await db.dropDatabase()
         resolve();
       })
@@ -360,7 +361,7 @@ describe('comments', function () {
           done()
         })
   });
-  
+
   it('should create reward pool', (done) => {
     new Promise(async (resolve) => {
       await fixture.setUp();
@@ -1728,7 +1729,6 @@ describe('comments', function () {
         done();
       });
   });
-
 
   it('vote past payout is ignored', (done) => {
     new Promise(async (resolve) => {

--- a/test/crittermanager.js
+++ b/test/crittermanager.js
@@ -59,6 +59,7 @@ describe('crittermanager', function() {
   afterEach((done) => {
       // runs after each test in this block
       new Promise(async (resolve) => {
+        fixture.tearDown();
         await db.dropDatabase()
         resolve();
       })

--- a/test/distribution.js
+++ b/test/distribution.js
@@ -165,6 +165,7 @@ describe('distribution', function () {
   afterEach((done) => {
       // runs after each test in this block
       new Promise(async (resolve) => {
+        fixture.tearDown();
         await db.dropDatabase()
         resolve();
       })
@@ -634,7 +635,7 @@ describe('distribution', function () {
         fixture.tearDown();
         done();
       });
-  });    
+  });
 
   it('should flush fixed distribution', (done) => {
     new Promise(async (resolve) => {
@@ -1529,6 +1530,5 @@ describe('distribution', function () {
       });
 
   });
-
   /// END TESTS
 });

--- a/test/hivepegged.js
+++ b/test/hivepegged.js
@@ -55,6 +55,7 @@ describe('Hive Pegged', function () {
   afterEach((done) => {
       // runs after each test in this block
       new Promise(async (resolve) => {
+        fixture.tearDown();
         await db.dropDatabase()
         resolve();
       })

--- a/test/hivesmartcontracts.js
+++ b/test/hivesmartcontracts.js
@@ -149,6 +149,7 @@ describe('Smart Contracts', function ()  {
   afterEach((done) => {
       // runs after each test in this block
       new Promise(async (resolve) => {
+        fixture.tearDown();
         await db.dropDatabase()
         resolve();
       })
@@ -1381,6 +1382,7 @@ describe('Smart Contracts', function ()  {
       };
 
       await fixture.sendBlock(block);
+      await tableAsserts.assertNoErrorInLastBlock();
 
       const latestBlock = await fixture.database.getLatestBlockInfo();
 
@@ -1399,6 +1401,7 @@ describe('Smart Contracts', function ()  {
         done();
       });
   });
+
 
   it('should trim executionCodeHash after cutoff', (done) => {
     new Promise(async (resolve) => {
@@ -1476,7 +1479,6 @@ describe('Smart Contracts', function ()  {
         done();
       });
   });
-
 
   it('should log a node error during the deployment of a smart contract if an error is thrown up to block 83680408', (done) => {
     new Promise(async (resolve) => {

--- a/test/market.js
+++ b/test/market.js
@@ -58,6 +58,7 @@ describe('Market', function() {
   afterEach((done) => {
       // runs after each test in this block
       new Promise(async (resolve) => {
+        fixture.tearDown();
         await db.dropDatabase()
         resolve();
       })

--- a/test/marketpools.js
+++ b/test/marketpools.js
@@ -144,6 +144,7 @@ describe('marketpools tests', function () {
   afterEach((done) => {
       // runs after each test in this block
       new Promise(async (resolve) => {
+        fixture.tearDown();
         await db.dropDatabase()
         resolve();
       })

--- a/test/mining.js
+++ b/test/mining.js
@@ -174,7 +174,8 @@ async function finishPowerUpdate(poolId) {
   };
   let res = await fixture.database.findOne(poolQuery);
   let refBlockNumber;
-  while (res.updating.inProgress) {
+  let updateCount = 0;
+  while (res.updating.inProgress && updateCount < 20) {
     refBlockNumber = fixture.getNextRefBlockNumber();
     const block = {
       refHiveBlockNumber: refBlockNumber,
@@ -185,6 +186,7 @@ async function finishPowerUpdate(poolId) {
     };
     await fixture.sendBlock(block);
     res = await fixture.database.findOne(poolQuery);
+    updateCount++;
   }
 }
 
@@ -226,6 +228,7 @@ describe('mining', function () {
   afterEach((done) => {
       // runs after each test in this block
       new Promise(async (resolve) => {
+        fixture.tearDown();
         await db.dropDatabase()
         resolve();
       })
@@ -3775,5 +3778,4 @@ describe('mining', function () {
       });
 
   });
-
 });

--- a/test/nft.js
+++ b/test/nft.js
@@ -102,6 +102,7 @@ describe('nft', function() {
   afterEach((done) => {
       // runs after each test in this block
       new Promise(async (resolve) => {
+        fixture.tearDown();
         await db.dropDatabase()
         resolve();
       })

--- a/test/nftairdrops.js
+++ b/test/nftairdrops.js
@@ -88,6 +88,7 @@ describe('NFT Airdrops Smart Contract', function () {
   afterEach((done) => {
     // runs after each test in this block
     new Promise(async (resolve) => {
+      fixture.tearDown();
       await db.dropDatabase();
       resolve();
     })

--- a/test/nftauction.js
+++ b/test/nftauction.js
@@ -122,6 +122,7 @@ describe('NFT Auction Smart Contract', function () {
   afterEach((done) => {
     // runs after each test in this block
     new Promise(async (resolve) => {
+      fixture.tearDown();
       await db.dropDatabase();
       resolve();
     })
@@ -1083,6 +1084,7 @@ describe('NFT Auction Smart Contract', function () {
       };
 
       await fixture.sendBlock(block);
+      await tableAsserts.assertNoErrorInLastBlock();
 
       const res = await fixture.database.getLatestBlockInfo();
       const txs = res.transactions;
@@ -1091,8 +1093,6 @@ describe('NFT Auction Smart Contract', function () {
       await assertBalances(['cryptomancer', 'dave', 'bidmaker', 'ali-h', "mart"], ['100', '100', '0', '99', "1"], 'BEE');
 
       await assertAuction('AUCTION-TX', true);
-
-      await tableAsserts.assertNoErrorInLastBlock();
 
       resolve();
     })

--- a/test/nftmarket.js
+++ b/test/nftmarket.js
@@ -59,6 +59,7 @@ describe('nftmarket', function() {
   afterEach((done) => {
       // runs after each test in this block
       new Promise(async (resolve) => {
+        fixture.tearDown();
         await db.dropDatabase()
         resolve();
       })
@@ -576,6 +577,7 @@ describe('nftmarket', function() {
       };
 
       await fixture.sendBlock(block);
+      await tableAsserts.assertNoErrorInLastBlock();
 
       // check if the NFT instances were sent to the buyer
       instances = await fixture.database.find({

--- a/test/packmanager.js
+++ b/test/packmanager.js
@@ -74,6 +74,7 @@ describe('packmanager', function() {
   afterEach((done) => {
       // runs after each test in this block
       new Promise(async (resolve) => {
+        fixture.tearDown();
         await db.dropDatabase()
         resolve();
       })

--- a/test/smarttokens.js
+++ b/test/smarttokens.js
@@ -108,6 +108,7 @@ describe('smart tokens', function () {
   afterEach((done) => {
       // runs after each test in this block
       new Promise(async (resolve) => {
+        fixture.tearDown();
         await db.dropDatabase()
         resolve();
       })

--- a/test/ticks.js
+++ b/test/ticks.js
@@ -74,6 +74,7 @@ describe('ticks', function () {
   afterEach((done) => {
       // runs after each test in this block
       new Promise(async (resolve) => {
+        fixture.tearDown();
         await db.dropDatabase()
         resolve();
       })

--- a/test/tokenfunds.js
+++ b/test/tokenfunds.js
@@ -173,6 +173,7 @@ describe('tokenfunds tests', function () {
   afterEach((done) => {
       // runs after each test in this block
       new Promise(async (resolve) => {
+        fixture.tearDown();
         await db.dropDatabase()
         resolve();
       })

--- a/test/tokens.js
+++ b/test/tokens.js
@@ -58,6 +58,7 @@ describe('Tokens smart contract', function () {
   afterEach((done) => {
       // runs after each test in this block
       new Promise(async (resolve) => {
+        fixture.tearDown();
         await db.dropDatabase()
         resolve();
       })

--- a/test/witnesses.js
+++ b/test/witnesses.js
@@ -93,6 +93,7 @@ describe('witnesses', function () {
   afterEach((done) => {
     // runs after each test in this block
     new Promise(async (resolve) => {
+      fixture.tearDown();
       await db.dropDatabase()
       resolve();
     })
@@ -2647,5 +2648,4 @@ describe('witnesses', function () {
         done();
       });
   });
-
 });


### PR DESCRIPTION
Introduces shims for BigNumber and validator libraries which require wrapping references while inside vm and unwrapping them when they are used in vm-external code (e.g. when BigNumber is passed to and from DB calls for find/update). 