### PR TITLE
Improve updateTradesHistory performance

### DIFF
--- a/contracts/market.js
+++ b/contracts/market.js
@@ -153,7 +153,7 @@ const updateTradesHistory = async (type, buyer, seller, symbol, quantity, price,
       volumeToDelete = volumeToDelete.plus(trade.volume);
       await api.db.remove('tradesHistory', trade);
     }
-    await updateVolumeMetric(trade.symbol, volumeToDelete, false);
+    await updateVolumeMetric(symbol, volumeToDelete, false);
     tradesToDelete = await api.db.find(
       'tradesHistory',
       {


### PR DESCRIPTION
This PR tries to improve the `updateTradesHistory` method of the `market` contract:
* adds an index for the `timestamp` column of the `market_tradesHistory` table
* call `updateVolumeMetric` only once