### PR TITLE
Move blacklist cleanup to tick action for market

### DIFF
--- a/contracts/market.js
+++ b/contracts/market.js
@@ -289,9 +289,9 @@ const removeBlacklistedOrdersBatch = async (type, symbol, targetAccount, qty) =>
       await api.db.remove(table, order);
     }
     if (type === 'sell') {
-      await updateAskMetric(order.symbol);
+      await updateAskMetric(symbol);
     } else {
-      await updateBidMetric(order.symbol);
+      await updateBidMetric(symbol);
     }
   }
 };

--- a/contracts/market.js
+++ b/contracts/market.js
@@ -267,13 +267,14 @@ const removeBlacklistedOrders = async (type, targetAccount) => {
   }
 };
 
-const removeBlacklistedOrdersBatch = async (type, targetAccount, qty) => {
+const removeBlacklistedOrdersBatch = async (type, symbol, targetAccount, qty) => {
   const table = type === 'buy' ? 'buyBook' : 'sellBook';
   let nbOrdersToDelete = 0;
   const ordersToDelete = await api.db.find(
     table,
     {
       account: targetAccount,
+      symbol,
     },
     qty,
     0,
@@ -286,12 +287,11 @@ const removeBlacklistedOrdersBatch = async (type, targetAccount, qty) => {
       const order = ordersToDelete[index];
 
       await api.db.remove(table, order);
-
-      if (type === 'sell') {
-        await updateAskMetric(order.symbol);
-      } else {
-        await updateBidMetric(order.symbol);
-      }
+    }
+    if (type === 'sell') {
+      await updateAskMetric(order.symbol);
+    } else {
+      await updateBidMetric(order.symbol);
     }
   }
 };
@@ -302,7 +302,7 @@ const removeExpiredOrders = async (table) => {
     .toNumber();
 
   // get rid of some blacklisted orders while we're here
-  await removeBlacklistedOrdersBatch('sell', 'shaggroed', 5);
+  await removeBlacklistedOrdersBatch('sell', 'TVST', 'shaggroed', 5);
 
   // clean orders
   let nbOrdersToDelete = 0;

--- a/contracts/market.js
+++ b/contracts/market.js
@@ -1374,6 +1374,6 @@ actions.marketSell = async (payload) => {
 actions.tick = async () => {
   if (api.assert(api.sender === 'null', `not authorized: ${api.sender}`)) {
     // get rid of some blacklisted orders while we're here
-    await removeBlacklistedOrdersBatch('sell', 'TVST', 'shaggroed', 100);
+    await removeBlacklistedOrdersBatch('sell', 'TVST', 'shaggroed', 10);
   }
 }

--- a/contracts/market.js
+++ b/contracts/market.js
@@ -301,9 +301,6 @@ const removeExpiredOrders = async (table) => {
     .dividedBy(1000)
     .toNumber();
 
-  // get rid of some blacklisted orders while we're here
-  await removeBlacklistedOrdersBatch('sell', 'TVST', 'shaggroed', 5);
-
   // clean orders
   let nbOrdersToDelete = 0;
   let ordersToDelete = await api.db.find(
@@ -1373,3 +1370,10 @@ actions.marketSell = async (payload) => {
     }
   }
 };
+
+actions.tick = async () => {
+  if (api.assert(api.sender === 'null', `not authorized: ${api.sender}`)) {
+    // get rid of some blacklisted orders while we're here
+    await removeBlacklistedOrdersBatch('sell', 'TVST', 'shaggroed', 100);
+  }
+}

--- a/test/market.js
+++ b/test/market.js
@@ -2578,4 +2578,69 @@ describe('Market', function() {
         done();
       });
   });
+
+  it('ticks and removes blacklisted orders', (done) => {
+    new Promise(async (resolve) => {
+
+      await fixture.setUp();
+
+      let refBlockNumber = fixture.getNextRefBlockNumber();
+      let transactions = [];
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'contract', 'update', JSON.stringify(tknContractPayload)));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_PEGGED_ACCOUNT, 'contract', 'update', JSON.stringify(pegContractPayload)));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'contract', 'update', JSON.stringify(mktContractPayload)));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'contract', 'registerTick', '{ "contractName": "market", "tickAction": "tick" }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'harpagon', 'accounts', 'register', ''));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'satoshi', 'accounts', 'register', ''));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'vitalik', 'accounts', 'register', ''));
+
+      let block = {
+        refHiveBlockNumber: refBlockNumber,
+        refHiveBlockId: 'ABCD1',
+        prevRefHiveBlockId: 'ABCD2',
+        timestamp: '2018-06-01T00:00:00',
+        transactions,
+      };
+
+      await fixture.sendBlock(block);
+
+      // now add a blacklisted order, and add new block
+      await fixture.database.insert({
+        contract: 'market',
+        table: 'sellBook',
+        record: {
+          account: 'shaggroed',
+          symbol: 'TVST'
+        },
+      });
+
+      refBlockNumber = fixture.getNextRefBlockNumber();
+      transactions = [];
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'satoshi', 'whatever', 'whatever', '')); // No-op to force block creation.
+      block = {
+        refHiveBlockNumber: refBlockNumber,
+        refHiveBlockId: 'ABCD2',
+        prevRefHiveBlockId: 'ABCD1',
+        timestamp: '2018-06-01T00:00:00',
+        transactions,
+      }
+      await fixture.sendBlock(block);
+
+      let sellOrders = await fixture.database.find({
+        contract: 'market',
+        table: 'sellBook',
+        query: {
+          account: 'shaggroed',
+          symbol: 'TVST'
+        }
+      });
+
+      assert.equal(sellOrders.length, 0);
+      resolve();
+    })
+      .then(() => {
+        fixture.tearDown();
+        done();
+      });
+  });
 });


### PR DESCRIPTION
Changes to look for symbol and account to speed up the fetch, and move to tick action to control the number of entries removed per block.