### PR TITLE
Fix witness multi broadcast in p2p plugin

### DIFF
--- a/plugins/P2P.js
+++ b/plugins/P2P.js
@@ -336,6 +336,11 @@ const manageRoundProposition = async () => {
       return;
     }
 
+    if (currentRound === lastProposedRoundNumber) {
+      // Already finished with current round
+      return;
+    }
+
     // handle round propositions
     const block = await database.getBlockInfo(lastBlockRound);
 


### PR DESCRIPTION
Handle case where we broadcast early but it thinks it needs to do it again