### PR TITLE
Using setUTCDate & getUTCDate for calculation of time duration

### DIFF
--- a/contracts/resourcemanager.js
+++ b/contracts/resourcemanager.js
@@ -249,7 +249,7 @@ actions.subscribe = async (payload) => {
   if (!api.assert(transferIsSuccessful(feeTransfer, 'transfer', api.sender, 'null', burnParams.burnSymbol, burnParams.allowlistBurnFee), 'not enough tokens for allowList fee')) return;
 
   const date = new Date(`${api.hiveBlockTimestamp}.000Z`);
-  date.setDate(date.getDate() + 30);
+  date.setUTCDate(date.getUTCDate() + 30);
 
   if (!accountControl) accountControl = { account: sender, isDenied: false, isAllowed: true };
 


### PR DESCRIPTION
Will avoid calculation issues due to timezone effects like summer or winter time which ends in divergend blocks at some nodes.