### PR TITLE
fix: Add timeout to plugin stop requests, correctly propagate termination signals during graceful shutdown

### DIFF
--- a/app.js
+++ b/app.js
@@ -127,7 +127,16 @@ const unloadPlugin = async (plugin) => {
   const plg = getPlugin(plugin);
   if (plg) {
     logger.info(`unloading plugin ${plugin.PLUGIN_NAME}`);
-    res = await send(plg, { action: 'stop' });
+    // res = await send(plg, { action: 'stop' });
+    // Add timeout to prevent hanging if plugin doesn't respond
+    const timeout = new Promise((resolve) => setTimeout(() => {
+      logger.error(`[${plugin.PLUGIN_NAME}] stop request timed out`);
+      resolve(null);
+    }, 2000));
+
+    const sendPromise = send(plg, { action: 'stop' });
+    res = await Promise.race([sendPromise, timeout]);
+
     plg.cp.kill('SIGINT');
   }
   return res;
@@ -162,8 +171,18 @@ const saveConfig = (lastBlockParsed) => {
 const stopApp = async (signal = 0) => {
   const lastBlockParsed = await stop();
   saveConfig(lastBlockParsed);
-  // calling process.exit() won't inform parent process of signal
-  process.kill(process.pid, signal);
+
+  if (signal && signal !== 0) {
+    // We received a signal (SIGINT/SIGTERM). 
+    // To let the parent know we died of this signal, we need to remove our listeners
+    // and re-send the signal to ourselves. This triggers the default handler (termination).
+    process.removeAllListeners('SIGINT');
+    process.removeAllListeners('SIGTERM');
+    process.kill(process.pid, signal);
+  } else {
+    // Normal exit or no specific signal passed
+    process.exit(0);
+  }
 };
 
 // graceful app closing

--- a/app.js
+++ b/app.js
@@ -132,7 +132,7 @@ const unloadPlugin = async (plugin) => {
     const timeout = new Promise((resolve) => setTimeout(() => {
       logger.error(`[${plugin.PLUGIN_NAME}] stop request timed out`);
       resolve(null);
-    }, 2000));
+    }, 6000));
 
     const sendPromise = send(plg, { action: 'stop' });
     res = await Promise.race([sendPromise, timeout]);


### PR DESCRIPTION
### Description
I run the node as a systemd service and I noticed it always timed out waiting for shutdown or restart. So I looked into it.

The current signal handling logic in app.js is flawed. It catches `SIGINT`/`SIGTERM`, performs cleanup, and then re-sends the signal to the process using `process.kill(process.pid, signal)`. However, since the custom signal handler is still active, it catches the re-sent signal, checks the `shuttingDown` flag (which is now true), and simply returns, leaving the process running indefinitely.

Additionally, I found that during cleanup, some plugins (like P2P or Streamer) might not respond to the IPC message if they are in a bad state, causing `unloadPlugin` to hang indefinitely while awaiting the response.

### Changes
1.  **Refined Signal Propagation**: In `stopApp`, explicitly remove the `SIGINT`/`SIGTERM` listeners before re-sending the signal. This ensures the default signal handler takes over and terminates the process correctly.
2.  **Added Plugin Timeout**: Added a 2-second timeout to the `unloadPlugin` function. If a plugin does not acknowledge the stop request within 2 seconds, the main process logs an error and force-kills the plugin, preventing the entire shutdown process from hanging.

### Verification
- Tested manually by running the node and sending `SIGINT`.
- Verified that the process now exits immediately after "Saving config" with the correct exit signal, even if plugins are unresponsive.