### PR TITLE
Create index on transactions.blockNumber for lite nodes

### DIFF
--- a/libs/Database.js
+++ b/libs/Database.js
@@ -152,6 +152,7 @@ class Database {
       this.chain = await this.database.createCollection('chain', { session: this.session });
 
       await this.database.createCollection('transactions', { session: this.session });
+      await this.database.collection('transactions').createIndex({ blockNumber: 1 });
       await this.database.createCollection('contracts', { session: this.session });
     } else {
       this.chain = coll;


### PR DESCRIPTION
## **Problem**

During lite node operations, the LightNode plugin periodically purges historical data. The transaction cleanup logic in libs/Database.js executes the following query every 10 minutes:

```javascript  
await this.database.collection('transactions').deleteMany({ blockNumber: { $lte: cleanupUntilBlock } });
```

Because the transactions collection lacked an index on blockNumber, MongoDB was forced to perform a full collection scan (COLLSCAN) through approximately 40 million records (\~3.19 GB) per cycle. This created severe, compounding overhead on system memory, CPU utilization, and disk I/O.

## **Solution**

- **Manual Mitigation:** Successfully verified the fix by manually building the index on the target database:  

```javascript
  db.transactions.createIndex({ blockNumber: 1 })
```

- **Programmatic Fix:** Updated libs/Database.js to ensure this index is automatically created on startup, preventing regressions on fresh node deployments.

## **Impact**

- Eliminates the 10-minute COLLSCAN spikes.
- Drastically reduces ambient CPU usage and disk I/O bottlenecks for all node operators running a lite strategy.