### PR TITLE
feat(config): expose VM and MongoDB pool tuning

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,26 @@ looping (though with transactions there is less risk of data corruption). Anothe
  that you may need to clear node processes after a stop if the process does not terminate on its own. 
 Otherwise it will interfere with logging.
 
+### Optional performance settings
+
+The following optional settings can be added to `config.json`:
+
+```json
+{
+  "maxJSVMs": 5,
+  "databasePool": {
+    "maxPoolSize": 20,
+    "minPoolSize": 2,
+    "maxIdleTimeMS": 30000,
+    "waitQueueTimeoutMS": 10000
+  }
+}
+```
+
+`maxJSVMs` controls the maximum number of JavaScript VM isolates available for contract execution. It must be a positive integer; when omitted or invalid, it defaults to `5`.
+
+`databasePool` controls the MongoDB connection pool when unified topology is enabled. `maxPoolSize` and `minPoolSize` control the connection count, `maxIdleTimeMS` closes idle connections, and `waitQueueTimeoutMS` limits how long an operation waits for an available connection. When `databasePool` is omitted, the MongoDB driver's defaults are preserved. Witness nodes generally need fewer connections, while public RPC nodes may benefit from a larger pool.
+
 Also, with isolated-vm on node 20 and later, you will need to pass in --no-node-snapshot to node:
 
 E.g.

--- a/config.example.json
+++ b/config.example.json
@@ -4,6 +4,8 @@
     "p2pPort": 5001,
     "databaseURL": "mongodb://127.0.0.1:27017",
     "databaseName": "hsc",
+    "maxJSVMs": 5,
+    "databasePool": {},
     "blocksLogFilePath": "./blocks.log",
     "javascriptVMTimeout": 10000,
     "streamNodes": [

--- a/libs/Database.js
+++ b/libs/Database.js
@@ -137,7 +137,14 @@ class Database {
 
   async init(databaseURL, databaseName, lightNode = false, blocksToKeep = 864000) {
     // init the database
-    this.client = await MongoClient.connect(databaseURL, { useNewUrlParser: true, useUnifiedTopology: true });
+    const databasePool = config.databasePool && typeof config.databasePool === 'object'
+      ? config.databasePool
+      : {};
+    this.client = await MongoClient.connect(databaseURL, {
+      useNewUrlParser: true,
+      useUnifiedTopology: true,
+      ...databasePool,
+    });
     this.database = await this.client.db(databaseName);
     this.lightNode = lightNode;
     this.blocksToKeep = blocksToKeep; // this only applies if lightNode is true

--- a/libs/SmartContracts.js
+++ b/libs/SmartContracts.js
@@ -11,12 +11,16 @@ const log = require('loglevel');
 const validator = require('validator');
 const seedrandom = require('seedrandom');
 const { CONSTANTS } = require('../libs/Constants');
+const config = require('../config.json');
 
 const RESERVED_CONTRACT_NAMES = ['contract', 'blockProduction', 'null'];
 const RESERVED_ACTIONS = ['createSSC'];
 
 const JSVMs = [];
-const MAXJSVMs = 5;
+const configuredMAXJSVMs = Number(config.maxJSVMs);
+const MAXJSVMs = Number.isInteger(configuredMAXJSVMs) && configuredMAXJSVMs > 0
+  ? configuredMAXJSVMs
+  : 5;
 
 const maybeDeref = (y) => typeof y === 'object' && y !== null && y.deref ? y.deref() : y;
 function deepDeref(x) {


### PR DESCRIPTION
Allow operators to tune the JavaScript VM isolate limit through maxJSVMs while retaining the historical limit of 5 when the key is absent or invalid.

Pass optional databasePool settings through to the MongoDB 3.6.3 unified-topology client without changing the existing driver defaults when the setting is omitted.

Document the supported settings, defaults, and witness/RPC sizing guidance in the README. Keep the example configuration valid JSON by leaving databasePool empty there.

Validation: test/hivesmartcontracts.js (25 passing)